### PR TITLE
Modify defaultKeyModifier to allow pretty urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import mime from 'mime/lite'
 
 const defaultKeyModifier = pathname => {
-  if (pathname === '/') {
-    pathname = '/index.html'
+  if (pathname.endsWith('/')) {
+    pathname = pathname.concat('index.html')
   }
   return pathname
 }


### PR DESCRIPTION
Some static site generators, like Hugo, use pretty urls; e.g.
`gabbifish.com/about/` instead of `gabbifish.com/about.html`.

These generators put the actual file for the about page in the path `public/about/index.html`. This means our default key modifier logic should not just work for `/` => `/index.html`, but also for anything ending with `/`. Like `gabbifish.com/about/` => `gabbifish.com/about/index.html`. Voila!

More about pretty urls: https://gohugo.io/content-management/urls/