### PR TITLE
Fix key lookup for paths like /about -> get /about/index.html key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const defaultKeyModifier = pathname => {
   // E.g. If path is /about, get /about/index.html
   // This logic ensures that weird paths with ".", like /about.me/,
   // also produce /about.me/index.html (expected).
-  if (pathname.lastIndexOf("/") > pathname.lastIndexOf(".")) {
+  else if (!pathname.endsWith('/') && !mime.getType(pathname)) {
     pathname = pathname.concat('/index.html')
   }
   return pathname

--- a/test/index.js
+++ b/test/index.js
@@ -10,11 +10,23 @@ const getEvent = request => {
   }
 }
 
-test('defaultKeyModifier() correctly changes /about/ -> /about/index.html'), async t => {
-  let path = '/about';
-  let key = defaultKeyModifier(path);
-  t.is(key, "/about/index.html");
-}
+test('defaultKeyModifier() correctly changes /about -> /about/index.html', async t => {
+  let path = '/about'
+  let key = defaultKeyModifier(path)
+  t.is(key, "/about/index.html")
+})
+
+test('defaultKeyModifier() correctly changes /about/ -> /about/index.html', async t => {
+  let path = '/about/'
+  let key = defaultKeyModifier(path)
+  t.is(key, "/about/index.html")
+})
+
+test('defaultKeyModifier() correctly changes /about.me/ -> /about.me/index.html', async t => {
+  let path = '/about.me/'
+  let key = defaultKeyModifier(path)
+  t.is(key, "/about.me/index.html")
+})
 
 test('getAssetFromKV return correct val from KV and default caching', async t => {
   mockGlobal()


### PR DESCRIPTION
Fixes #10.

Ensures that, if path is `/about`, get `/about/index.html`. This logic ensures that weird paths with `"."`, like `/about.me/`, also produce `/about.me/index.html` (expected).