### PR TITLE
Put all key modification logic in default key modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
 addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request))
 })
-
+const customKeyModifier = url => {
+  //custom key mapping optional
+  if (url.endsWith('/')) url += 'index.html'
+  return url.replace('/docs', '').replace(/^\/+/, '')
+}
 async function handleRequest(request) {
   if (request.url.includes('/docs')) {
     try {
-      return await getAssetFromKV(request, url => {
-        //custom key mapping optional
-        if (url.endsWith('/')) url += 'index.html'
-        return url.replace('/docs', '')
-      })
+      return await getAssetFromKV(request, customKeyModifier)
     } catch (e) {
       return new Response(`"${customKeyModifier(request.url)}" not found`, {
         status: 404,

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ const defaultKeyModifier = pathname => {
   else if (!pathname.endsWith('/') && !mime.getType(pathname)) {
     pathname = pathname.concat('/index.html')
   }
+  // remove prepended /
+  pathname = pathname.replace(/^\/+/, '')
   return pathname
 }
 const defaultCacheControl = {
@@ -41,10 +43,7 @@ const getAssetFromKV = async (event, options) => {
     throw new Error(`there is no ${ASSET_NAMESPACE} namespace bound to the script`)
   }
   const parsedUrl = new URL(request.url)
-  const pathname = options.keyModifier(parsedUrl.pathname)
-
-  // remove prepended /
-  let key = pathname.slice(1)
+  let key = options.keyModifier(parsedUrl.pathname)
 
   const cache = caches.default
 
@@ -89,7 +88,7 @@ const getAssetFromKV = async (event, options) => {
     headers.set('CF-Cache-Status', 'HIT')
     response = new Response(response.body, { headers })
   } else {
-    const mimeType = mime.getType(pathname)
+    const mimeType = mime.getType(key)
     const body = await __STATIC_CONTENT.get(key, 'arrayBuffer')
     if (body === null) {
       throw new Error(`could not find ${key} in your content namespace`)

--- a/test/index.js
+++ b/test/index.js
@@ -10,22 +10,22 @@ const getEvent = request => {
   }
 }
 
-test('defaultKeyModifier() correctly changes /about -> /about/index.html', async t => {
+test('defaultKeyModifier() correctly changes /about -> about/index.html', async t => {
   let path = '/about'
   let key = defaultKeyModifier(path)
-  t.is(key, "/about/index.html")
+  t.is(key, 'about/index.html')
 })
 
-test('defaultKeyModifier() correctly changes /about/ -> /about/index.html', async t => {
+test('defaultKeyModifier() correctly changes /about/ -> about/index.html', async t => {
   let path = '/about/'
   let key = defaultKeyModifier(path)
-  t.is(key, "/about/index.html")
+  t.is(key, 'about/index.html')
 })
 
-test('defaultKeyModifier() correctly changes /about.me/ -> /about.me/index.html', async t => {
+test('defaultKeyModifier() correctly changes /about.me/ -> about.me/index.html', async t => {
   let path = '/about.me/'
   let key = defaultKeyModifier(path)
-  t.is(key, "/about.me/index.html")
+  t.is(key, 'about.me/index.html')
 })
 
 test('getAssetFromKV return correct val from KV and default caching', async t => {
@@ -62,7 +62,7 @@ test('getAssetFromKV custom key modifier', async t => {
     if (pathname === '/') {
       pathname += 'index.html'
     }
-    return pathname.replace('/docs', '')
+    return pathname.replace('/docs', '').replace(/^\/+/, '')
   }
 
   const res = await getAssetFromKV(event, { keyModifier: customKeyModifier })


### PR DESCRIPTION
During QA session sites were breaking because we assume there is always a prepended `/` . this is safer now by using regex over `slice` and putting this logic in the defaultKeyModifier

* Note I had to change the custom keyModifier test logic since it behaves differently without this assumption 