### PR TITLE
Update defaultKeyModifier to take a request instead of a pathname

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import mime from 'mime'
  * the content of bucket/index.html
  * @param {Request} request incoming request
  */
-const defaultRequestKeyModifier = request => {
+const mapRequestToAsset = request => {
   const parsedUrl = new URL(request.url)
   let pathname = parsedUrl.pathname
 
@@ -36,7 +36,7 @@ const defaultCacheControl = {
  * the response
  *
  * @param {event} event the fetch event of the triggered request
- * @param {{requestKeyModifier: (string: Request) => Request, cacheControl: {bypassCache:boolean, edgeTTL: number, browserTTL:number}, ASSET_NAMESPACE: any, ASSET_MANIFEST:any}} [options] configurable options
+ * @param {{mapRequestToAsset: (string: Request) => Request, cacheControl: {bypassCache:boolean, edgeTTL: number, browserTTL:number}, ASSET_NAMESPACE: any, ASSET_MANIFEST:any}} [options] configurable options
  * @param {CacheControl} [options.cacheControl] determine how to cache on Cloudflare and the browser
  * @param {any} [options.ASSET_NAMESPACE] the binding to the namespace that script references
  * @param {any} [options.ASSET_MANIFEST] the map of the key to cache and store in KV
@@ -47,7 +47,7 @@ const getAssetFromKV = async (event, options) => {
     {
       ASSET_NAMESPACE: __STATIC_CONTENT,
       ASSET_MANIFEST: __STATIC_CONTENT_MANIFEST,
-      requestKeyModifier: defaultRequestKeyModifier,
+      mapRequestToAsset: mapRequestToAsset,
       cacheControl: defaultCacheControl,
     },
     options,
@@ -66,7 +66,7 @@ const getAssetFromKV = async (event, options) => {
   }
 
   // determine the requestKey based on the actual file served for the incoming request
-  const requestKey = options.requestKeyModifier(request)
+  const requestKey = options.mapRequestToAsset(request)
   const parsedUrl = new URL(requestKey.url)
 
   const pathname = parsedUrl.pathname
@@ -145,4 +145,4 @@ const getAssetFromKV = async (event, options) => {
   return response
 }
 
-export { getAssetFromKV, defaultRequestKeyModifier }
+export { getAssetFromKV, mapRequestToAsset }

--- a/test/index.js
+++ b/test/index.js
@@ -1,26 +1,26 @@
 import test from 'ava'
 import { mockGlobal, getEvent } from '../src/mocks'
-import { getAssetFromKV, defaultRequestKeyModifier } from '../src/index'
+import { getAssetFromKV, mapRequestToAsset } from '../src/index'
 
-test('defaultRequestKeyModifier() correctly changes /about -> /about/index.html', async t => {
+test('mapRequestToAsset() correctly changes /about -> /about/index.html', async t => {
   mockGlobal()
   let path = '/about'
   let request = new Request(`https://foo.com${path}`)
-  let newRequest = defaultRequestKeyModifier(request)
+  let newRequest = mapRequestToAsset(request)
   t.is(newRequest.url, request.url + '/index.html')
 })
 
-test('defaultRequestKeyModifier() correctly changes /about/ -> /about/index.html', async t => {
+test('mapRequestToAsset() correctly changes /about/ -> /about/index.html', async t => {
   let path = '/about/'
   let request = new Request(`https://foo.com${path}`)
-  let newRequest = defaultRequestKeyModifier(request)
+  let newRequest = mapRequestToAsset(request)
   t.is(newRequest.url, request.url + 'index.html')
 })
 
-test('defaultRequestKeyModifier() correctly changes /about.me/ -> /about.me/index.html', async t => {
+test('mapRequestToAsset() correctly changes /about.me/ -> /about.me/index.html', async t => {
   let path = '/about.me/'
   let request = new Request(`https://foo.com${path}`)
-  let newRequest = defaultRequestKeyModifier(request)
+  let newRequest = mapRequestToAsset(request)
   t.is(newRequest.url, request.url + 'index.html')
 })
 
@@ -67,15 +67,15 @@ test('getAssetFromKV custom key modifier', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/docs/sub/blah.png'))
 
-  const customRequestKeyModifier = request => {
-    let defaultModifiedRequest = defaultRequestKeyModifier(request)
+  const customRequestMapper = request => {
+    let defaultModifiedRequest = mapRequestToAsset(request)
 
     let url = new URL(defaultModifiedRequest.url)
     url.pathname = url.pathname.replace('/docs', '')
     return new Request(url, request)
   }
 
-  const res = await getAssetFromKV(event, { requestKeyModifier: customRequestKeyModifier })
+  const res = await getAssetFromKV(event, { mapRequestToAsset: customRequestMapper })
 
   if (res) {
     t.is(await res.text(), 'picturedis')


### PR DESCRIPTION
Updates the defaultKeyModifier -> mapRequestToAsset to take in a request instead of a pathname. The motivation here is to provide users (and ourselves) with the ability to determine the lookup path for a given asset based on an entire request, rather than just the path of the request, which would allow us to view relevant headers (like `Accept` and its variants) to determine the correct asset to serve.