### PR TITLE
Fix browser cache headers from always being set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,7 @@ const getAssetFromKV = async (event, options) => {
   if (options.cacheControl.bypassCache) {
     shouldEdgeCache = false
   }
+  // only set max-age if explictly passed in a number as an arg
   const shouldSetBrowserCache = typeof options.cacheControl.browserTTL === 'number'
 
   let response = null
@@ -123,10 +124,10 @@ const getAssetFromKV = async (event, options) => {
     let headers = new Headers(response.headers)
     headers.set('CF-Cache-Status', 'HIT')
     if (shouldSetBrowserCache) {
-      // don't assume we want same cache behavior on client
-      // so remove the header from the response we'll return
       headers.set('cache-control', `max-age=${options.cacheControl.browserTTL}`)
     } else {
+      // don't assume we want same cache behavior of edge TTL on client
+      // so remove the header from the response we'll return
       headers.delete('cache-control')
     }
     response = new Response(response.body, { headers })

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ const getAssetFromKV = async (event, options) => {
   const ASSET_NAMESPACE = options.ASSET_NAMESPACE
   const ASSET_MANIFEST = options.ASSET_MANIFEST
 
-  const SUPPORTED_METHODS = ["GET", "HEAD"]
+  const SUPPORTED_METHODS = ['GET', 'HEAD']
 
   if (!SUPPORTED_METHODS.includes(request.method)) {
     throw new Error(`${request.method} is not a valid request method`)
@@ -112,6 +112,8 @@ const getAssetFromKV = async (event, options) => {
   if (options.cacheControl.bypassCache) {
     shouldEdgeCache = false
   }
+  const shouldSetBrowserCache =
+    options.cacheControl.browserTTL === 0 || options.cacheControl.browserTTL
 
   let response = null
   if (shouldEdgeCache) {
@@ -121,10 +123,12 @@ const getAssetFromKV = async (event, options) => {
   if (response) {
     let headers = new Headers(response.headers)
     headers.set('CF-Cache-Status', 'HIT')
-    if (options.cacheControl.browserTTL !== 0 && !options.cacheControl.browserTTL){
+    if (shouldSetBrowserCache) {
+      // don't assume we want same cache behavior on client
+      // so remove the header from the response we'll return
+      headers.set('cache-control', `max-age=${options.cacheControl.browserTTL}`)
+    } else {
       headers.delete('cache-control')
-    }else{
-      headers.set('cache-control', `max-age=${options.browserTTL}`)
     }
     response = new Response(response.body, { headers })
   } else {
@@ -141,14 +145,13 @@ const getAssetFromKV = async (event, options) => {
       // determine Cloudflare cache behavior
       response.headers.set('Cache-Control', `max-age=${options.cacheControl.edgeTTL}`)
       event.waitUntil(cache.put(cacheKey, response.clone()))
-      // don't assume we want same cache behavior on client
-      // so remove the header from the response we'll return
-      response.headers.delete('Cache-Control')
     }
   }
   response.headers.set('Content-Type', mimeType)
-  if (options.cacheControl.browserTTL === 0 || !options.cacheControl.browserTTL) {
+  if (shouldSetBrowserCache) {
     response.headers.set('Cache-Control', `max-age=${options.cacheControl.browserTTL}`)
+  } else {
+    response.headers.delete('Cache-Control')
   }
   return response
 }

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ const getAssetFromKV = async (event, options) => {
   if (response) {
     let headers = new Headers(response.headers)
     headers.set('CF-Cache-Status', 'HIT')
-    if(options.browserTTL === null ){
+    if (options.cacheControl.browserTTL !== 0 && !options.cacheControl.browserTTL){
       headers.delete('cache-control')
     }else{
       headers.set('cache-control', `max-age=${options.browserTTL}`)
@@ -147,7 +147,7 @@ const getAssetFromKV = async (event, options) => {
     }
   }
   response.headers.set('Content-Type', mimeType)
-  if (options.cacheControl.browserTTL !== null) {
+  if (options.cacheControl.browserTTL === 0 || !options.cacheControl.browserTTL) {
     response.headers.set('Cache-Control', `max-age=${options.cacheControl.browserTTL}`)
   }
   return response

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const mapRequestToAsset = request => {
 
 const defaultCacheControl = {
   browserTTL: null,
-  edgeTTL: 100 * 60 * 60 * 24, // 100 days
+  edgeTTL: 2 * 60 * 60 * 24, // 2 days
   bypassCache: false, // do not bypass Cloudflare's cache
 }
 
@@ -147,7 +147,7 @@ const getAssetFromKV = async (event, options) => {
     }
   }
   response.headers.set('Content-Type', mimeType)
-  if (options.cacheControl.browserTTL) {
+  if (options.cacheControl.browserTTL !== null) {
     response.headers.set('Cache-Control', `max-age=${options.cacheControl.browserTTL}`)
   }
   return response

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ const mapRequestToAsset = request => {
 }
 
 const defaultCacheControl = {
-  browserTTL: 0,
+  browserTTL: null,
   edgeTTL: 100 * 60 * 60 * 24, // 100 days
   bypassCache: false, // do not bypass Cloudflare's cache
 }
@@ -121,6 +121,11 @@ const getAssetFromKV = async (event, options) => {
   if (response) {
     let headers = new Headers(response.headers)
     headers.set('CF-Cache-Status', 'HIT')
+    if(options.browserTTL === null ){
+      headers.delete('cache-control')
+    }else{
+      headers.set('cache-control', `max-age=${options.browserTTL}`)
+    }
     response = new Response(response.body, { headers })
   } else {
     const body = await __STATIC_CONTENT.get(pathKey, 'arrayBuffer')

--- a/src/index.js
+++ b/src/index.js
@@ -112,8 +112,7 @@ const getAssetFromKV = async (event, options) => {
   if (options.cacheControl.bypassCache) {
     shouldEdgeCache = false
   }
-  const shouldSetBrowserCache =
-    options.cacheControl.browserTTL === 0 || options.cacheControl.browserTTL
+  const shouldSetBrowserCache = typeof options.cacheControl.browserTTL === 'number'
 
   let response = null
   if (shouldEdgeCache) {


### PR DESCRIPTION
For cache HITs we always returned the edge cache TTLs to the client, which in turn means the browser would be caching as long as the edge does (100 days)

```
curl -X 'GET' -v https://sites.workers-tooling.cf/workers/ 2>&1 | grep cache
< cf-cache-status: HIT
< cache-control: public, max-age=8640000
```

Also, I set the edge cache to a safer, more realistic value (no edge would likely not get close to caching an asset for 100 days)

fixes #38 