### PR TITLE
Add tests and fix mocks for browser TTL issue

### DIFF
--- a/src/mocks.js
+++ b/src/mocks.js
@@ -3,8 +3,8 @@ const makeServiceWorkerEnv = require('service-worker-mock')
 const HASH = '123HASHBROWN'
 
 export const getEvent = request => {
-  const waitUntil = callback => {
-    callback
+  const waitUntil = async callback => {
+    await callback
   }
   return {
     request,
@@ -43,7 +43,9 @@ export const mockCaches = () => {
         return cacheStore[key] || null
       },
       put: (key, val) => {
-        return (cacheStore[key] = val)
+        let headers = new Headers(val.headers)
+        let resp = new Response(val.body, { headers })
+        return (cacheStore[key] = resp)
       },
     },
   }

--- a/test/index.js
+++ b/test/index.js
@@ -144,6 +144,26 @@ test('getAssetFromKV caches on two sequential requests', async t => {
     t.fail('Response was undefined')
   }
 })
+test('getAssetFromKV does not store max-age on two sequential requests', async t => {
+  mockGlobal()
+  const sleep = milliseconds => {
+    return new Promise(resolve => setTimeout(resolve, milliseconds))
+  }
+  const event = getEvent(new Request('https://blah.com/cache.html'))
+
+  const res1 = await getAssetFromKV(event, { cacheControl: { edgeTTL: 720 } })
+  await sleep(100)
+  const res2 = await getAssetFromKV(event)
+
+  if (res1 && res2) {
+    t.is(res1.headers.get('cf-cache-status'), 'MISS')
+    t.is(res1.headers.get('cache-control'), null)
+    t.is(res2.headers.get('cf-cache-status'), 'HIT')
+    t.is(res2.headers.get('cache-control'), null)
+  } else {
+    t.fail('Response was undefined')
+  }
+})
 
 test('getAssetFromKV does not cache on Cloudflare when bypass cache set', async t => {
   mockGlobal()


### PR DESCRIPTION
Add test for caching browser TTL 

Could've caught https://github.com/cloudflare/kv-asset-handler/issues/38
