### PR TITLE
Fix README example not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ npm i @cloudflare/kv-asset-handler
 
 ## Usage
 
-Currently this exports a single function `getAssetFromKV` that maps `Request` objects to KV Assets, and throws an `Error` if it cannot.
+Currently this exports a single function `getAssetFromKV` that maps `FetchEvent` objects to KV Assets, and throws an `Error` if it cannot.
 
 ```js
 import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
 ```
 
-`getAssetFromKV` is a function that takes a `Request` object and returns a `Response` object if the request matches an asset in KV, otherwise it will throw an `Error`.
+`getAssetFromKV` is a function that takes a `FetchEvent` object and returns a `Response` object if the request matches an asset in KV, otherwise it will throw an `Error`.
 
 Note this package was designed to work with Worker Sites. If you are not using Sites make sure to call the bucket you are serving assets from `__STATIC_CONTENT`
 
@@ -29,23 +29,23 @@ This example checks for the existence of a value in KV, and returns it if it's t
 import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
 
 addEventListener('fetch', event => {
-  event.respondWith(handleRequest(event.request))
+  event.respondWith(handleEvent(event))
 })
 const customKeyModifier = url => {
   //custom key mapping optional
   if (url.endsWith('/')) url += 'index.html'
   return url.replace('/docs', '').replace(/^\/+/, '')
 }
-async function handleRequest(request) {
-  if (request.url.includes('/docs')) {
+async function handleEvent(event) {
+  if (event.request.url.includes('/docs')) {
     try {
-      return await getAssetFromKV(request, customKeyModifier)
+      return await getAssetFromKV(event, customKeyModifier)
     } catch (e) {
-      return new Response(`"${customKeyModifier(request.url)}" not found`, {
+      return new Response(`"${customKeyModifier(event.request.url)}" not found`, {
         status: 404,
         statusText: 'not found',
       })
     }
-  } else return fetch(request)
+  } else return fetch(event.request)
 }
 ```


### PR DESCRIPTION
Hey there!

When trying to work off of the example code provided in the README I noticed that the parameters being passed to `getAssetFromKV` have changed since the example was created, causing the code to break.

I tried to update it to prevent other users from running into the same issue - please let me know if anything needs to be changed.