### PR TITLE
Fix tests for custom namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   }
 
   if (typeof ASSET_NAMESPACE === 'undefined') {
-    throw new InternalError(`there is no ASSET_NAMESPACE namespace bound to the script`)
+    throw new InternalError(`there is no KV namespace bound to the script`)
   }
 
   // determine the requestKey based on the actual file served for the incoming request

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   }
 
   if (typeof ASSET_NAMESPACE === 'undefined') {
-    throw new InternalError(`there is no ${ASSET_NAMESPACE} namespace bound to the script`)
+    throw new InternalError(`there is no ASSET_NAMESPACE namespace bound to the script`)
   }
 
   // determine the requestKey based on the actual file served for the incoming request
@@ -159,7 +159,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
     }
     response = new Response(response.body, { headers })
   } else {
-    const body = await __STATIC_CONTENT.get(pathKey, 'arrayBuffer')
+    const body = await ASSET_NAMESPACE.get(pathKey, 'arrayBuffer')
     if (body === null) {
       throw new NotFoundError(`could not find ${pathKey} in your content namespace`)
     }

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -217,11 +217,12 @@ test('getAssetFromKV passing in a custom NAMESPACE serves correct asset', async 
 test('getAssetFromKV when custom namespace without the asset should fail', async t => {
   mockGlobal()
   let CUSTOM_NAMESPACE = mockKV({
-    'key1.123HASHBROWN.txt': 'val1',
+    'key5.123HASHBROWN.txt': 'customvalu',
   })
-  Object.assign(global, { CUSTOM_NAMESPACE })
 
-  const event = getEvent(new Request('https://blah.com/'))
-  const error: KVError = await t.throwsAsync(getAssetFromKV(event))
+  const event = getEvent(new Request('https://blah.com'))
+  const error: KVError = await t.throwsAsync(
+    getAssetFromKV(event, { ASSET_NAMESPACE: CUSTOM_NAMESPACE }),
+  )
   t.is(error.status, 404)
 })

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -229,7 +229,7 @@ test('getAssetFromKV when custom namespace without the asset should fail', async
 test('getAssetFromKV when namespace not bound fails', async t => {
   mockGlobal()
   var MY_CUSTOM_NAMESPACE = undefined
-  Object.assign(global, { MY_CUSTOM_NAMESPACE: undefined })
+  Object.assign(global, { MY_CUSTOM_NAMESPACE })
 
   const event = getEvent(new Request('https://blah.com/'))
   const error: KVError = await t.throwsAsync(

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -226,3 +226,14 @@ test('getAssetFromKV when custom namespace without the asset should fail', async
   )
   t.is(error.status, 404)
 })
+test('getAssetFromKV when namespace not bound fails', async t => {
+  mockGlobal()
+  var MY_CUSTOM_NAMESPACE = undefined
+  Object.assign(global, { MY_CUSTOM_NAMESPACE: undefined })
+
+  const event = getEvent(new Request('https://blah.com/'))
+  const error: KVError = await t.throwsAsync(
+    getAssetFromKV(event, { ASSET_NAMESPACE: MY_CUSTOM_NAMESPACE }),
+  )
+  t.is(error.status, 500)
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type Options = {
   mapRequestToAsset: (req: Request) => Request
 }
 
-class KVError extends Error {
+export class KVError extends Error {
   constructor(message?: string, status: number = 500) {
     super(message)
     // see: typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html


### PR DESCRIPTION
accidentally merged some of these changes in [error handling PR](https://github.com/cloudflare/kv-asset-handler/pull/64) when I saw comments relevant to this PR on that other branch... and that's my bad 😬
Changes already merged in were to fix the tests:
* Add tests for custom namespace  https://github.com/cloudflare/kv-asset-handler/pull/64/commits/151825a29f1e352d6820deaee245e74a7b27cfa0
* Have mocks pass in store https://github.com/cloudflare/kv-asset-handler/pull/64/commits/27f9ae54ba5faafa645fe9400976810349e4c693

This PR just fixes some loss ends with the tests and implementation

fixes #67 