### PR TITLE
Allow extensionless file paths to be served

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as mime from 'mime'
 import { Options, CacheControl, MethodNotAllowedError, NotFoundError, InternalError } from './types'
 
 declare global {
-  var __STATIC_CONTENT: any, __STATIC_CONTENT_MANIFEST: any
+  var __STATIC_CONTENT: any, __STATIC_CONTENT_MANIFEST: string
 }
 /**
  * maps the path of incoming request to the request pathKey to look up
@@ -65,7 +65,7 @@ const defaultCacheControl: CacheControl = {
  * @param {{mapRequestToAsset: (string: Request) => Request, cacheControl: {bypassCache:boolean, edgeTTL: number, browserTTL:number}, ASSET_NAMESPACE: any, ASSET_MANIFEST:any}} [options] configurable options
  * @param {CacheControl} [options.cacheControl] determine how to cache on Cloudflare and the browser
  * @param {typeof(options.mapRequestToAsset)} [options.mapRequestToAsset]  maps the path of incoming request to the request pathKey to look up
- * @param {any} [options.ASSET_NAMESPACE] the binding to the namespace that script references
+ * @param {Object | string} [options.ASSET_NAMESPACE] the binding to the namespace that script references
  * @param {any} [options.ASSET_MANIFEST] the map of the key to cache and store in KV
  * */
 const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Promise<Response> => {
@@ -82,7 +82,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
 
   const request = event.request
   const ASSET_NAMESPACE = options.ASSET_NAMESPACE
-  const ASSET_MANIFEST = options.ASSET_MANIFEST
+  const ASSET_MANIFEST = typeof (options.ASSET_MANIFEST) === 'string'
     ? JSON.parse(options.ASSET_MANIFEST)
     : options.ASSET_MANIFEST
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
     throw new MethodNotAllowedError(`${request.method} is not a valid request method`)
   }
 
-  const rawPathKey = new URL(request.url).pathname.replace(/^\/+/, '') // original request's pathname (e.g. foo/filename)
+  const rawPathKey = new URL(request.url).pathname.replace(/^\/+/, '') // strip any preceding /'s 
   //set to the raw file if exists, else the approriate HTML file
   const requestKey = ASSET_MANIFEST[rawPathKey] ? request : options.mapRequestToAsset(request)
   const parsedUrl = new URL(requestKey.url)
@@ -113,7 +113,8 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   if (typeof ASSET_MANIFEST !== 'undefined') {
     if (ASSET_MANIFEST[pathKey]) {
       pathKey = ASSET_MANIFEST[pathKey]
-      shouldEdgeCache = true // cache on edge if pathKey contains a unique hash
+      // if path key is in asset manifest, we can assume it contains a content hash and can be cached
+      shouldEdgeCache = true
     }
   }
 

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -18,6 +18,8 @@ const store: any = {
   'cache.123HASHBROWN.html': 'cache me if you can',
   'nohash.txt': 'no hash but still got some result',
   'sub/blah.123HASHBROWN.png': 'picturedis',
+  'client.123HASHBROWN': 'important file',
+  'client.123HASHBROWN/index.html': 'Im here but serve my big bro above',
 }
 export const mockKV = (store: any) => {
   return {
@@ -32,6 +34,8 @@ export const mockManifest = () => {
     'cache.html': `cache.${HASH}.html`,
     'index.html': `index.${HASH}.html`,
     'sub/blah.png': `sub/blah.${HASH}.png`,
+    'client': `client.${HASH}`,
+    'client/index.html': `client.${HASH}`,
   })
 }
 let cacheStore: any = {}

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -18,6 +18,7 @@ const store: any = {
   'cache.123HASHBROWN.html': 'cache me if you can',
   'nohash.txt': 'no hash but still got some result',
   'sub/blah.123HASHBROWN.png': 'picturedis',
+  'sub/index.123HASHBROWN.html': 'picturedis',
   'client.123HASHBROWN': 'important file',
   'client.123HASHBROWN/index.html': 'Im here but serve my big bro above',
 }
@@ -34,6 +35,7 @@ export const mockManifest = () => {
     'cache.html': `cache.${HASH}.html`,
     'index.html': `index.${HASH}.html`,
     'sub/blah.png': `sub/blah.${HASH}.png`,
+    'sub/index.html': `sub/index.${HASH}.html`,
     'client': `client.${HASH}`,
     'client/index.html': `client.${HASH}`,
   })

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -52,6 +52,17 @@ test('getAssetFromKV if no asset manifest /client -> client fails', async t => {
   t.is(error.status, 404)
 })
 
+test('getAssetFromKV if sub/ -> sub/index.html served', async t => {
+  mockGlobal()
+  const event = getEvent(new Request(`https://foo.com/sub`))
+  const res = await getAssetFromKV(event)
+  if (res) {
+    t.is(await res.text(), 'picturedis')
+  } else {
+    t.fail('Response was undefined')
+  }
+})
+
 test('getAssetFromKV gets index.html by default for / requests', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -45,6 +45,13 @@ test('getAssetFromKV if not in asset manifest still returns nohash.txt', async t
   }
 })
 
+test('getAssetFromKV if no asset manifest /client -> client fails', async t => {
+  mockGlobal()
+  const event = getEvent(new Request(`https://foo.com/client`))
+  const error: KVError = await t.throwsAsync(getAssetFromKV(event, { ASSET_MANIFEST: {} }))
+  t.is(error.status, 404)
+})
+
 test('getAssetFromKV gets index.html by default for / requests', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -17,6 +17,21 @@ test('getAssetFromKV return correct val from KV and default caching', async t =>
     t.fail('Response was undefined')
   }
 })
+test('getAssetFromKV evaluated the file matching the extensionless path first /client/ -> client', async t => {
+  mockGlobal()
+  const event = getEvent(new Request(`https://foo.com/client/`))
+  const res = await getAssetFromKV(event)
+  t.is(await res.text(), 'important file')
+  t.true(res.headers.get('content-type').includes('text'))
+})
+test('getAssetFromKV evaluated the file matching the extensionless path first /client -> client', async t => {
+  mockGlobal()
+  const event = getEvent(new Request(`https://foo.com/client`))
+  const res = await getAssetFromKV(event)
+  t.is(await res.text(), 'important file')
+  t.true(res.headers.get('content-type').includes('text'))
+})
+
 test('getAssetFromKV if not in asset manifest still returns nohash.txt', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/nohash.txt'))

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export type CacheControl = {
 export type Options = {
   cacheControl: ((req: Request) => Partial<CacheControl>) | Partial<CacheControl>
   ASSET_NAMESPACE: any
-  ASSET_MANIFEST: any
+  ASSET_MANIFEST: Object | string
   mapRequestToAsset: (req: Request) => Request
 }
 


### PR DESCRIPTION
Checks asset manifest for the extensionless file matching the request first and then uses `mapRequestToAsset` to map the HTML equivalent if it doesn't exist. 
fixes part of https://github.com/cloudflare/wrangler/issues/980


Disclaimer: 
- One must have defined ASSET_MANIFEST to serve files without extensions. The technical reason is that we'd have to go through checking the cache and the KV for the extensionless asset (`filename` ) to validate it's there not an extensionless file present on every request _before_ checking the namespace for the .html equivalent. That would add latency and be complicated so I vote not to do that. This is a rare edge case and maybe we should just start requiring asset manifest? Or just document this and see if anyone even runs into that. 