### PR TITLE
Small fix on the readme for using serveSinglePageApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,5 +189,5 @@ A custom handler for mapping requests to a single root: `index.html`. The most c
 ```js
 import { getAssetFromKV, serveSinglePageApp } from '@cloudflare/kv-asset-handler'
 ...
-let asset = await getAssetFromKV(event.request, { mapRequestToAsset: serveSinglePageApp })
+let asset = await getAssetFromKV(event, { mapRequestToAsset: serveSinglePageApp })
 ```


### PR DESCRIPTION
Hey Cloudflare workers team 👋

A super small fix to the docs reg the `serveSinglePageApp` usage with `getAssetFromKv`. getAssetFromKv takes a FetchEvent, not a request,