### PR TITLE
0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   Prior to this PR, `getAssetFromKv` assumed extensionless requests (e.g. `/some-path`) would be set up to be served as the corresponding HTML file in storage (e.g. `some-path.html`).
   This fix checks the `ASSET_MANIFEST` for the extensionless file name _before_ appending the HTML extension. If the extensionless file exists (e.g. `some-path` exists as a key in the ASSET_MANIFEST) then we serve that file first. If the extensionless file does not exist, then the behavior does not change (e.g. it still looks for `some-path.html`).
 
+  [victoriabernard92]: https://github.com/victoriabernard92
+  [cloudflare/wrangler/issues/980]: https://github.com/cloudflare/wrangler/issues/980
+  [pull/73]: https://github.com/cloudflare/kv-asset-handler/pull/73
+
 - ### Fixes
 
   - **Fix URL parsing in serveSinglePageApp - [signalnerve],[sgiacosa], [issue/72], [pull/82]**
@@ -16,13 +20,22 @@
   This fixes an issue in `serveSinglePageApp` where the request.url is used as a string to retrieve static content. For example,
   if a query parameter was set, the URL lookup would break. This fix uses a parsed URL instead of the string and adjusts the README.
 
+  [signalnerve]: https://github.com/signalnerve
+  [sgiacosa]: https://github.com/sgiacosa
+  [issue/72]: https://github.com/cloudflare/kv-asset-handler/issue/72
+  [pull/82]: https://github.com/cloudflare/kv-asset-handler/pull/82
+
 ## 0.0.9
 
 - ### Fixes
-  
+
   - **Building and publishing to npm - [victoriabernard92], [pull/78], [pull/79]**
-   
-    Added a `prepack` step that builds JavaScript files from the TypeScript source. This fixes previously broken `npm` publishes.
+
+  Added a `prepack` step that builds JavaScript files from the TypeScript source. This fixes previously broken `npm` publishes.
+
+  [victoriabernard92]: https://github.com/victoriabernard92
+  [issue/78]: https://github.com/cloudflare/kv-asset-handler/issue/78
+  [pull/79]: https://github.com/cloudflare/kv-asset-handler/pull/79
 
 ## 0.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,7 @@
   
   - **Building and publishing to npm - [victoriabernard92], [pull/78], [pull/79]**
    
-    Publishing to npm started to break after we implemented in TypeScript because the `prepack` step 
-    was not set to build the JS files correctly
+    Added a `prepack` step that builds JavaScript files from the TypeScript source. This fixes previously broken `npm` publishes.
 
 ## 0.0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.0.10
+
+- ### Features
+
+  - **Allow extensionless files to be served - [victoriabernard92], [cloudflare/wrangler/issues/980], [pull/73]**
+
+  Prior to this PR, `getAssetFromKv` assumed extensionless requests (e.g. `/some-path`) would be set up to be served as the corresponding HTML file in storage (e.g. `some-path.html`).
+  This fix checks the `ASSET_MANIFEST` for the extensionless file name _before_ appending the HTML extension. If the extensionless file exists (e.g. `some-path` exists as a key in the ASSET_MANIFEST) then we serve that file first. If the extensionless file does not exist, then the behavior does not change (e.g. it still looks for `some-path.html`).
+
+- ### Fixes
+
+  - **Fix URL parsing in serveSinglePageApp - [signalnerve],[sgiacosa], [issue/72], [pull/82]**
+
+  This fixes an issue in `serveSinglePageApp` where the request.url is used as a string to retrieve static content. For example,
+  if a query parameter was set, the URL lookup would break. This fix uses a parsed URL instead of the string and adjusts the README.
+
+## 0.0.9
+
+- ### Fixes
+  
+  - **Building and publishing to npm - [victoriabernard92], [pull/78], [pull/79]**
+   
+    Publishing to npm started to break after we implemented in TypeScript because the `prepack` step 
+    was not set to build the JS files correctly
+
 ## 0.0.8
 
 - ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/kv-asset-handler",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Routes requests to KV assets",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,8 +22,8 @@
     "wrangler",
     "assets"
   ],
-  "author": "Avery Harnish",
-  "license": "MIT",
+  "author": "wrangler@cloudflare.com",
+  "license": "MIT OR Apache-2.0",
   "bugs": {
     "url": "https://github.com/cloudflare/kv-asset-handler/issues"
   },


### PR DESCRIPTION
0.0.9 didn't have a changelog since it was a quick publishing fix. This PR gets us ready for 0.0.10 by:

- adding 0.0.9 and 0.0.10 changelog
- cleaning up package.json