### PR TITLE
Fix invalid JavaScript in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,12 @@ async function handleEvent(event) {
     try {
       return await getAssetFromKV(event)
     } catch (e) {
-        switch (typeof resp) {
-          case NotFoundError: 
-            //..
-          case MethodNotAllowedError:
-            // ...
-          default:
-            return new Response("An unexpected error occurred", { status: 500 })
-        }
+      if (e instanceof NotFoundError) {
+        // ...
+      } else if (e instanceof MethodNotAllowedError) {
+        // ...
+      } else {
+        return new Response("An unexpected error occurred", { status: 500 })
       }
     }
   } else return fetch(event.request)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Known errors to be thrown are:
 - InternalError
   
 ```js
-import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
+import { getAssetFromKV, NotFoundError, MethodNotAllowedError } from '@cloudflare/kv-asset-handler'
 
 addEventListener('fetch', event => {
   event.respondWith(handleEvent(event))


### PR DESCRIPTION
This switch/typeof example isn't valid JavaScript AFAICT -- JS doesn't have "type switches" like Go does.

NOTE: Unfortunately this example still won't work, because NotFoundError and MethodNotAllowedError are not imported. It doesn't look like kv-asset-handler exports these types currently, so I guess a code change is needed to export them?

See #93 (not fully fixed by this PR)