### PR TITLE
Export all needed types via `dist/index.d.ts`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -200,3 +200,4 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
 }
 
 export { getAssetFromKV, mapRequestToAsset, serveSinglePageApp }
+export { Options, CacheControl, MethodNotAllowedError, NotFoundError, InternalError }


### PR DESCRIPTION
In order to publish types, the minimal change required is:
* Update `index.ts` to also export `Options, CacheControl,
  MethodNotAllowedError, NotFoundError, InternalError`
* `npm run build` (which runs `tsc -d`, where the `-d` flag indicates to
  generate type definition files)
* Cut a new release

I observed that this generates a `dist/index.d.ts` type definition file that
contains all types except those defined in `src/mock.ts`, which are only
required for package tests and thus don’t need to be published.

`package.json` already specifies these as the package’s types:
```json
"main": "dist/index.js",
"types": "dist/index.d.ts",
```

As a side note, I’m not sure why `index.d.ts` (even with a subset of types)
isn’t included in the `0.0.10` release. If I check out the `v0.0.10` tag and run
`npm publish —dry-run` I observe that it includes `dist/index.d.ts` in the
package. However, that file is not present in the built package from npm.

Finally, I tested that this works using `npm link` – reviewers can play along
too if you like. First, in this branch of `kv-asset-handler`, run `npm link`. 

Then, I created a new typescript project containing the updated sample code
from @kentonv’s PR against`README.md` in [#102](https://github.com/cloudflare/kv-asset-handler/pull/102/files#diff-04c6e90faac2675aa89e2176d2eec7d8), then ran:

```bash
npm i @cloudflare/kv-asset-handler --save
npm link @cloudflare/kv-asset-handler
```

This symlinks to the local copy of `kv-asset-handler` instead of the 0.0.10
release on npm. After doing so, I was able to do the following in said new
project:

```typescript
import { getAssetFromKV, NotFoundError, MethodNotAllowedError } from '@cloudflare/kv-asset-handler'
```

I validated that the new example code transpiles when using these typings.