### PR TITLE
Add defaultMimeType option to getAssetFromKV

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ let assetManifest = { "index.html": "index.special.html" }
 return getAssetFromKV(event, { ASSET_MANIFEST: JSON.stringify(assetManifest) })
 ```
 
+#### `defaultMimeType` (optional)
+
+type: string
+
+This is the mime type that will be used for files with unrecognized or missing extensions. The default value is `'text/plain'`.
+
+If you are serving a static site and would like to use extensionless HTML files instead of index.html files, set this to `'text/html'`.
+
 # Helper functions
 
 ## `mapRequestToAsset`

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
       ASSET_MANIFEST: __STATIC_CONTENT_MANIFEST,
       mapRequestToAsset: mapRequestToAsset,
       cacheControl: defaultCacheControl,
+      defaultMimeType: 'text/plain',
     },
     options,
   )
@@ -117,7 +118,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
 
   // @ts-ignore
   const cache = caches.default
-  let mimeType = mime.getType(pathKey) || 'text/plain'
+  let mimeType = mime.getType(pathKey) || options.defaultMimeType
   if (mimeType.startsWith('text')) {
       mimeType += '; charset=utf8'
   }


### PR DESCRIPTION
Some static website owners prefer not to create all of their web routes as directories containing index.html files. Instead, they prefer to create pages as extensionless HTML files. Providing a defaultMimeType option will allow users to set the Content-Type header for extensionless files to text/html, which will enable this use case.