### PR TITLE
Lint Markdown.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,7 +116,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -124,5 +124,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -56,7 +56,7 @@ Mistakes happen. Most of these release steps are recoverable if you mess up. The
 Tags and releases can be removed in GitHub. First, [remove the remote tag](https://stackoverflow.com/questions/5480258/how-to-delete-a-remote-tag):
 
 ```console
-$ git push --delete origin tagname
+git push --delete origin tagname
 ```
 
 This will turn the release into a `draft` and you can delete it from the edit page.
@@ -64,5 +64,5 @@ This will turn the release into a `draft` and you can delete it from the edit pa
 Make sure you also delete the local tag:
 
 ```console
-$ git tag --delete vX.X.X
+git tag --delete vX.X.X
 ```


### PR DESCRIPTION
Rules linted:
MD014/commands-show-output Dollar signs used before commands without showing output.
MD034/no-bare-urls  Bare URL used.

https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md