### PR TITLE
refactored etag logic. fixes 122

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   }
 
   if (response) {
-    if (response.status > 300) {
+    if (response.status > 300 && response.status < 400) {
       if (response.body && 'cancel' in Object.getPrototypeOf(response.body)) {
         response.body.cancel()
         console.log('Body exists and environment supports readable streams. Body cancelled')

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
 
   const request = event.request
   const ASSET_NAMESPACE = options.ASSET_NAMESPACE
-  const ASSET_MANIFEST = typeof options.ASSET_MANIFEST === 'string'
+  const ASSET_MANIFEST = typeof (options.ASSET_MANIFEST) === 'string'
       ? JSON.parse(options.ASSET_MANIFEST)
       : options.ASSET_MANIFEST
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,8 +85,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
 
   const request = event.request
   const ASSET_NAMESPACE = options.ASSET_NAMESPACE
-  const ASSET_MANIFEST =
-    typeof options.ASSET_MANIFEST === 'string'
+  const ASSET_MANIFEST = typeof options.ASSET_MANIFEST === 'string'
       ? JSON.parse(options.ASSET_MANIFEST)
       : options.ASSET_MANIFEST
 
@@ -104,13 +103,13 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   } else if (ASSET_MANIFEST[rawPathKey]) {
     requestKey = request
   } else if (ASSET_MANIFEST[decodeURIComponent(rawPathKey)]) {
-    pathIsEncoded = true
+    pathIsEncoded = true;
     requestKey = request
   } else {
     const mappedRequest = mapRequestToAsset(request)
     const mappedRawPathKey = new URL(mappedRequest.url).pathname.replace(/^\/+/, '')
     if (ASSET_MANIFEST[decodeURIComponent(mappedRawPathKey)]) {
-      pathIsEncoded = true
+      pathIsEncoded = true;
       requestKey = mappedRequest
     } else {
       // use default mapRequestToAsset

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,8 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   const request = event.request
   const ASSET_NAMESPACE = options.ASSET_NAMESPACE
   const ASSET_MANIFEST = typeof (options.ASSET_MANIFEST) === 'string'
-      ? JSON.parse(options.ASSET_MANIFEST)
-      : options.ASSET_MANIFEST
+    ? JSON.parse(options.ASSET_MANIFEST)
+    : options.ASSET_MANIFEST
 
   if (typeof ASSET_NAMESPACE === 'undefined') {
     throw new InternalError(`there is no KV namespace bound to the script`)
@@ -132,7 +132,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   const cache = caches.default
   let mimeType = mime.getType(pathKey) || options.defaultMimeType
   if (mimeType.startsWith('text') || mimeType === 'application/javascript') {
-    mimeType += '; charset=utf-8'
+      mimeType += '; charset=utf-8'
   }
 
   let shouldEdgeCache = false // false if storing in KV by raw file path i.e. no hash
@@ -211,7 +211,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   if (response) {
     if (response.status > 300 && response.status < 400) {
       if (response.body && 'cancel' in Object.getPrototypeOf(response.body)) {
-        response.body.cancel()
+        response.body.cancel();
         console.log('Body exists and environment supports readable streams. Body cancelled')
       } else {
         console.log('Environment doesnt support readable streams')
@@ -222,7 +222,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
       let opts = {
         headers: new Headers(response.headers),
         status: 0,
-        statusText: '',
+        statusText: ''
       }
 
       opts.headers.set('cf-cache-status', 'HIT')

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,6 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
         if (!entityId.startsWith('W/')) {
           return `W/${entityId}`
         }
-        console.log('weakened', entityId)
         return entityId
       case 'strong':
         if (entityId.startsWith(`W/"`)) {

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -26,7 +26,7 @@ const store: any = {
   'sub/index.123HASHBROWN.html': 'picturedis',
   'client.123HASHBROWN': 'important file',
   'client.123HASHBROWN/index.html': 'Im here but serve my big bro above',
-  '你好/index.123HASHBROWN.html': 'My path is non-ascii',
+  '你好/index.123HASHBROWN.html': 'My path is non-ascii'
 }
 export const mockKV = (store: any) => {
   return {

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -49,7 +49,7 @@ export const mockManifest = () => {
     'sub/index.html': `sub/index.${HASH}.html`,
     client: `client.${HASH}`,
     'client/index.html': `client.${HASH}`,
-    '你好/index.html': `你好/index.${HASH}.html`,
+    '你好/index.html': `你好/index.${HASH}.html`
   })
 }
 

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -26,7 +26,7 @@ const store: any = {
   'sub/index.123HASHBROWN.html': 'picturedis',
   'client.123HASHBROWN': 'important file',
   'client.123HASHBROWN/index.html': 'Im here but serve my big bro above',
-  '你好/index.123HASHBROWN.html': 'My path is non-ascii'
+  '你好/index.123HASHBROWN.html': 'My path is non-ascii',
 }
 export const mockKV = (store: any) => {
   return {
@@ -49,22 +49,22 @@ export const mockManifest = () => {
     'sub/index.html': `sub/index.${HASH}.html`,
     'client': `client.${HASH}`,
     'client/index.html': `client.${HASH}`,
-    '你好/index.html': `你好/index.${HASH}.html`
+    '你好/index.html': `你好/index.${HASH}.html`,
   })
 }
 
 let cacheStore: any = new Map()
 interface CacheKey {
-  url: object
-  headers: object
+  url:object;
+  headers:object
 }
 export const mockCaches = () => {
   return {
     default: {
-      async match(key: any) {
+      async match (key: any) {
         let cacheKey: CacheKey = {
           url: key.url,
-          headers: {},
+          headers: {}
         }
         let response
         if (key.headers.has('if-none-match')) {
@@ -105,7 +105,7 @@ export const mockCaches = () => {
         }
         return response
       },
-      async put(key: any, val: Response) {
+      async put (key: any, val: Response) {
         let headers = new Headers(val.headers)
         let url = new URL(key.url)
         let resWithBody = new Response(val.body, { headers, status: 200 })
@@ -113,8 +113,8 @@ export const mockCaches = () => {
         let cacheKey: CacheKey = {
           url: key.url,
           headers: {
-            etag: `"${url.pathname.replace('/', '')}"`,
-          },
+            'etag': `"${url.pathname.replace('/', '')}"`
+          }
         }
         cacheStore.set(JSON.stringify(cacheKey), resNoBody)
         cacheKey.headers = {}
@@ -132,5 +132,5 @@ export function mockGlobal() {
   Object.assign(global, { caches: mockCaches() })
 }
 export const sleep = (milliseconds: number) => {
-  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
 }

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -209,13 +209,11 @@ test('getAssetFromKV caches on two sequential requests', async t => {
   const resourceKey = 'cache.html'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
   const event1 = getEvent(new Request(`https://blah.com/${resourceKey}`))
-  const event2 = getEvent(
-    new Request(`https://blah.com/${resourceKey}`, {
-      headers: {
-        'if-none-match': `"${resourceVersion}"`,
-      },
-    }),
-  )
+  const event2 = getEvent(new Request(`https://blah.com/${resourceKey}`, {
+    headers: {
+      'if-none-match': resourceVersion
+    }
+  }))
 
   const res1 = await getAssetFromKV(event1, { cacheControl: { edgeTTL: 720, browserTTL: 720 } })
   await sleep(1)

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -3,7 +3,7 @@ import { mockGlobal, getEvent, sleep, mockKV, mockManifest } from '../mocks'
 import { getAssetFromKV, mapRequestToAsset } from '../index'
 import { KVError } from '../types'
 
-test('getAssetFromKV return correct val from KV and default caching', async (t) => {
+test('getAssetFromKV return correct val from KV and default caching', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/key1.txt'))
   const res = await getAssetFromKV(event)
@@ -17,14 +17,14 @@ test('getAssetFromKV return correct val from KV and default caching', async (t) 
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV evaluated the file matching the extensionless path first /client/ -> client', async (t) => {
+test('getAssetFromKV evaluated the file matching the extensionless path first /client/ -> client', async t => {
   mockGlobal()
   const event = getEvent(new Request(`https://foo.com/client/`))
   const res = await getAssetFromKV(event)
   t.is(await res.text(), 'important file')
   t.true(res.headers.get('content-type').includes('text'))
 })
-test('getAssetFromKV evaluated the file matching the extensionless path first /client -> client', async (t) => {
+test('getAssetFromKV evaluated the file matching the extensionless path first /client -> client', async t => {
   mockGlobal()
   const event = getEvent(new Request(`https://foo.com/client`))
   const res = await getAssetFromKV(event)
@@ -32,7 +32,7 @@ test('getAssetFromKV evaluated the file matching the extensionless path first /c
   t.true(res.headers.get('content-type').includes('text'))
 })
 
-test('getAssetFromKV if not in asset manifest still returns nohash.txt', async (t) => {
+test('getAssetFromKV if not in asset manifest still returns nohash.txt', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/nohash.txt'))
   const res = await getAssetFromKV(event)
@@ -45,14 +45,14 @@ test('getAssetFromKV if not in asset manifest still returns nohash.txt', async (
   }
 })
 
-test('getAssetFromKV if no asset manifest /client -> client fails', async (t) => {
+test('getAssetFromKV if no asset manifest /client -> client fails', async t => {
   mockGlobal()
   const event = getEvent(new Request(`https://foo.com/client`))
   const error: KVError = await t.throwsAsync(getAssetFromKV(event, { ASSET_MANIFEST: {} }))
   t.is(error.status, 404)
 })
 
-test('getAssetFromKV if sub/ -> sub/index.html served', async (t) => {
+test('getAssetFromKV if sub/ -> sub/index.html served', async t => {
   mockGlobal()
   const event = getEvent(new Request(`https://foo.com/sub`))
   const res = await getAssetFromKV(event)
@@ -63,7 +63,7 @@ test('getAssetFromKV if sub/ -> sub/index.html served', async (t) => {
   }
 })
 
-test('getAssetFromKV gets index.html by default for / requests', async (t) => {
+test('getAssetFromKV gets index.html by default for / requests', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))
   const res = await getAssetFromKV(event)
@@ -76,7 +76,7 @@ test('getAssetFromKV gets index.html by default for / requests', async (t) => {
   }
 })
 
-test('getAssetFromKV non ASCII path support', async (t) => {
+test('getAssetFromKV non ASCII path support', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/测试.html'))
   const res = await getAssetFromKV(event)
@@ -88,7 +88,7 @@ test('getAssetFromKV non ASCII path support', async (t) => {
   }
 })
 
-test('getAssetFromKV supports browser percent encoded URLs', async (t) => {
+test('getAssetFromKV supports browser percent encoded URLs', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://example.com/%not-really-percent-encoded.html'))
   const res = await getAssetFromKV(event)
@@ -100,7 +100,7 @@ test('getAssetFromKV supports browser percent encoded URLs', async (t) => {
   }
 })
 
-test('getAssetFromKV supports user percent encoded URLs', async (t) => {
+test('getAssetFromKV supports user percent encoded URLs', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/%2F.html'))
   const res = await getAssetFromKV(event)
@@ -112,7 +112,7 @@ test('getAssetFromKV supports user percent encoded URLs', async (t) => {
   }
 })
 
-test('getAssetFromKV only decode URL when necessary', async (t) => {
+test('getAssetFromKV only decode URL when necessary', async t => {
   mockGlobal()
   const event1 = getEvent(new Request('https://blah.com/%E4%BD%A0%E5%A5%BD.html'))
   const event2 = getEvent(new Request('https://blah.com/你好.html'))
@@ -127,7 +127,7 @@ test('getAssetFromKV only decode URL when necessary', async (t) => {
   }
 })
 
-test('getAssetFromKV Support for user decode url path', async (t) => {
+test('getAssetFromKV Support for user decode url path', async t => {
   mockGlobal()
   const event1 = getEvent(new Request('https://blah.com/%E4%BD%A0%E5%A5%BD/'))
   const event2 = getEvent(new Request('https://blah.com/你好/'))
@@ -142,7 +142,7 @@ test('getAssetFromKV Support for user decode url path', async (t) => {
   }
 })
 
-test('getAssetFromKV custom key modifier', async (t) => {
+test('getAssetFromKV custom key modifier', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/docs/sub/blah.png'))
 
@@ -163,7 +163,7 @@ test('getAssetFromKV custom key modifier', async (t) => {
   }
 })
 
-test('getAssetFromKV when setting browser caching', async (t) => {
+test('getAssetFromKV when setting browser caching', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))
 
@@ -176,7 +176,7 @@ test('getAssetFromKV when setting browser caching', async (t) => {
   }
 })
 
-test('getAssetFromKV when setting custom cache setting', async (t) => {
+test('getAssetFromKV when setting custom cache setting', async t => {
   mockGlobal()
   const event1 = getEvent(new Request('https://blah.com/'))
   const event2 = getEvent(new Request('https://blah.com/key1.png?blah=34'))
@@ -204,7 +204,7 @@ test('getAssetFromKV when setting custom cache setting', async (t) => {
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV caches on two sequential requests', async (t) => {
+test('getAssetFromKV caches on two sequential requests', async t => {
   mockGlobal()
   const resourceKey = 'cache.html'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
@@ -229,7 +229,7 @@ test('getAssetFromKV caches on two sequential requests', async (t) => {
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV does not store max-age on two sequential requests', async (t) => {
+test('getAssetFromKV does not store max-age on two sequential requests', async t => {
   mockGlobal()
   const resourceKey = 'cache.html'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
@@ -256,7 +256,7 @@ test('getAssetFromKV does not store max-age on two sequential requests', async (
   }
 })
 
-test('getAssetFromKV does not cache on Cloudflare when bypass cache set', async (t) => {
+test('getAssetFromKV does not cache on Cloudflare when bypass cache set', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))
 
@@ -270,7 +270,7 @@ test('getAssetFromKV does not cache on Cloudflare when bypass cache set', async 
   }
 })
 
-test('getAssetFromKV with no trailing slash on root', async (t) => {
+test('getAssetFromKV with no trailing slash on root', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com'))
   const res = await getAssetFromKV(event)
@@ -281,7 +281,7 @@ test('getAssetFromKV with no trailing slash on root', async (t) => {
   }
 })
 
-test('getAssetFromKV with no trailing slash on a subdirectory', async (t) => {
+test('getAssetFromKV with no trailing slash on a subdirectory', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/sub/blah.png'))
   const res = await getAssetFromKV(event)
@@ -292,13 +292,13 @@ test('getAssetFromKV with no trailing slash on a subdirectory', async (t) => {
   }
 })
 
-test('getAssetFromKV no result throws an error', async (t) => {
+test('getAssetFromKV no result throws an error', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/random'))
   const error: KVError = await t.throwsAsync(getAssetFromKV(event))
   t.is(error.status, 404)
 })
-test('getAssetFromKV TTls set to null should not cache on browser or edge', async (t) => {
+test('getAssetFromKV TTls set to null should not cache on browser or edge', async t => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))
 
@@ -315,7 +315,7 @@ test('getAssetFromKV TTls set to null should not cache on browser or edge', asyn
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV passing in a custom NAMESPACE serves correct asset', async (t) => {
+test('getAssetFromKV passing in a custom NAMESPACE serves correct asset', async t => {
   mockGlobal()
   let CUSTOM_NAMESPACE = mockKV({
     'key1.123HASHBROWN.txt': 'val1',
@@ -330,7 +330,7 @@ test('getAssetFromKV passing in a custom NAMESPACE serves correct asset', async 
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV when custom namespace without the asset should fail', async (t) => {
+test('getAssetFromKV when custom namespace without the asset should fail', async t => {
   mockGlobal()
   let CUSTOM_NAMESPACE = mockKV({
     'key5.123HASHBROWN.txt': 'customvalu',
@@ -342,7 +342,7 @@ test('getAssetFromKV when custom namespace without the asset should fail', async
   )
   t.is(error.status, 404)
 })
-test('getAssetFromKV when namespace not bound fails', async (t) => {
+test('getAssetFromKV when namespace not bound fails', async t => {
   mockGlobal()
   var MY_CUSTOM_NAMESPACE = undefined
   Object.assign(global, { MY_CUSTOM_NAMESPACE })
@@ -354,7 +354,7 @@ test('getAssetFromKV when namespace not bound fails', async (t) => {
   t.is(error.status, 500)
 })
 
-test('getAssetFromKV when if-none-match === active resource version, should revalidate', async (t) => {
+test('getAssetFromKV when if-none-match === active resource version, should revalidate', async t => {
   mockGlobal()
   const resourceKey = 'key1.png'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
@@ -379,7 +379,7 @@ test('getAssetFromKV when if-none-match === active resource version, should reva
   }
 })
 
-test('getAssetFromKV when if-none-match equals etag of stale resource then should bypass cache', async (t) => {
+test('getAssetFromKV when if-none-match equals etag of stale resource then should bypass cache', async t => {
   mockGlobal()
   const resourceKey = 'key1.png'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
@@ -408,7 +408,7 @@ test('getAssetFromKV when if-none-match equals etag of stale resource then shoul
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV when resource in cache, etag should be weakened before returned to eyeball', async (t) => {
+test('getAssetFromKV when resource in cache, etag should be weakened before returned to eyeball', async t => {
   mockGlobal()
   const resourceKey = 'key1.png'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
@@ -428,7 +428,7 @@ test('getAssetFromKV when resource in cache, etag should be weakened before retu
   }
 })
 
-test('getAssetFromKV if-none-match not sent but resource in cache, should return cache hit 200 OK', async (t) => {
+test('getAssetFromKV if-none-match not sent but resource in cache, should return cache hit 200 OK', async t => {
   const resourceKey = 'cache.html'
   const event = getEvent(new Request(`https://blah.com/${resourceKey}`))
   const res1 = await getAssetFromKV(event, { cacheControl: { edgeTTL: 720 } })
@@ -444,7 +444,7 @@ test('getAssetFromKV if-none-match not sent but resource in cache, should return
   }
 })
 
-test('getAssetFromKV if range request submitted and resource in cache, request fulfilled', async (t) => {
+test('getAssetFromKV if range request submitted and resource in cache, request fulfilled', async t => {
   const resourceKey = 'cache.html'
   const event1 = getEvent(new Request(`https://blah.com/${resourceKey}`))
   const event2 = getEvent(
@@ -454,7 +454,6 @@ test('getAssetFromKV if range request submitted and resource in cache, request f
   await res1
   await sleep(2)
   const res2 = await getAssetFromKV(event2)
-  console.log(res2.headers)
   if (res2.headers.has('content-range')) {
     t.is(res2.status, 206)
   } else {


### PR DESCRIPTION
The TL;DR on issue #122 : I discovered that when a Worker subrequest ...
* Sets a strong etag before `caches.default.put()` (like `etag: "xyc"`)
* But weakens this etag to `etag: W/"xyc"` before serving eyeball

Then ...
* CF cache will respond with a 304 to the Worker 
* After subrequest leaves the worker, we will honor the 304 AND apply brotili or gzip compression