### PR TITLE
Fixes issue #139 - Only parse `ASSET_MANIFEST` once on isolate startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as mime from 'mime'
-import { Options, CacheControl, MethodNotAllowedError, NotFoundError, InternalError } from './types'
+import { Options, CacheControl, MethodNotAllowedError, NotFoundError, InternalError, AssetManifestType } from './types'
 
 declare global {
   var __STATIC_CONTENT: any, __STATIC_CONTENT_MANIFEST: string
@@ -59,6 +59,19 @@ const defaultCacheControl: CacheControl = {
   bypassCache: false, // do not bypass Cloudflare's cache
 }
 
+
+const parseStringAsObject = <T>(maybestring: string | T): T => 
+  typeof maybestring === 'string' ? JSON.parse(maybestring) as T : maybestring
+
+
+const getAssetFromKVDefaultOptions: Partial<Options> = {
+  ASSET_NAMESPACE: __STATIC_CONTENT,
+  ASSET_MANIFEST: parseStringAsObject<AssetManifestType>(__STATIC_CONTENT_MANIFEST),
+  mapRequestToAsset: mapRequestToAsset,
+  cacheControl: defaultCacheControl,
+  defaultMimeType: 'text/plain',
+}
+
 /**
  * takes the path of the incoming request, gathers the appropriate content from KV, and returns
  * the response
@@ -73,22 +86,13 @@ const defaultCacheControl: CacheControl = {
 const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Promise<Response> => {
   // Assign any missing options passed in to the default
   options = Object.assign(
-    {
-      ASSET_NAMESPACE: __STATIC_CONTENT,
-      ASSET_MANIFEST: __STATIC_CONTENT_MANIFEST,
-      mapRequestToAsset: mapRequestToAsset,
-      cacheControl: defaultCacheControl,
-      defaultMimeType: 'text/plain',
-    },
+    getAssetFromKVDefaultOptions,
     options,
   )
 
   const request = event.request
   const ASSET_NAMESPACE = options.ASSET_NAMESPACE
-  const ASSET_MANIFEST = typeof (options.ASSET_MANIFEST) === 'string'
-    ? JSON.parse(options.ASSET_MANIFEST)
-    : options.ASSET_MANIFEST
-
+  const ASSET_MANIFEST = parseStringAsObject<AssetManifestType>(options.ASSET_MANIFEST)
   if (typeof ASSET_NAMESPACE === 'undefined') {
     throw new InternalError(`there is no KV namespace bound to the script`)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,10 +3,13 @@ export type CacheControl = {
   edgeTTL: number
   bypassCache: boolean
 }
+
+export type AssetManifestType = Record<string, string>;
+
 export type Options = {
   cacheControl: ((req: Request) => Partial<CacheControl>) | Partial<CacheControl>
   ASSET_NAMESPACE: any
-  ASSET_MANIFEST: Object | string
+  ASSET_MANIFEST: AssetManifestType | string
   mapRequestToAsset: (req: Request) => Request,
   defaultMimeType: string
 }


### PR DESCRIPTION
This should fix issue #139 where ASSET_MANIFEST is parsed on each call to getAssetFromKV.

I'm currently using this library for a medium to large gatsby project (734MB over 53232 files) and this change would improve our performance quite a bit.