### PR TITLE
Revert "Fixes issue #139 - Only parse `ASSET_MANIFEST` once on isolat…

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,13 +3,10 @@ export type CacheControl = {
   edgeTTL: number
   bypassCache: boolean
 }
-
-export type AssetManifestType = Record<string, string>;
-
 export type Options = {
   cacheControl: ((req: Request) => Partial<CacheControl>) | Partial<CacheControl>
   ASSET_NAMESPACE: any
-  ASSET_MANIFEST: AssetManifestType | string
+  ASSET_MANIFEST: Object | string
   mapRequestToAsset: (req: Request) => Request,
   defaultMimeType: string
 }


### PR DESCRIPTION
…e startup"

This reverts commit bd154e6687208d6c809a0350f221d164e22d41b1.

I verified that before reverting, most tests fail locally due to failures to resolve the asset manifest at runtime, i.e. the test failures we see in CI. After reverting, tests pass.

@groenlid apologies we have to revert this in order to unblock a release – it looks like tests didn't automatically run against your PR, so we didn't notice that it broke tests.