### PR TITLE
Append "; charset=utf-8" to application/javascript mime type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   // @ts-ignore
   const cache = caches.default
   let mimeType = mime.getType(pathKey) || options.defaultMimeType
-  if (mimeType.startsWith('text')) {
+  if (mimeType.startsWith('text') || mimeType === 'application/javascript') {
       mimeType += '; charset=utf-8'
   }
 


### PR DESCRIPTION
Currently, `; charset=utf-8` is only appended to mime types starting with `text`. This includes the mime type `text/javascript`.
Because of that, I believe `application/javascript`, essentially the successor to `text/javascript`, should have special handling to achieve equality with `text/javascript` handling. This PR adds it.

Ultimately, I believe a better, more customizable solution is necessary. A library I use has a `AppendUtf8CharsetOnContentTypes` setting, which lets me choose which mime types I want to append `; charset=utf-8` to. Something similar should be considered here when active development resumes.