### PR TITLE
feat: fire mapRequestToAsset for all requests if explicitly defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,11 +72,11 @@ const defaultCacheControl: CacheControl = {
  * */
 const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Promise<Response> => {
   // Assign any missing options passed in to the default
+  // options.mapRequestToAsset is handled manually later
   options = Object.assign(
     {
       ASSET_NAMESPACE: __STATIC_CONTENT,
       ASSET_MANIFEST: __STATIC_CONTENT_MANIFEST,
-      mapRequestToAsset: mapRequestToAsset,
       cacheControl: defaultCacheControl,
       defaultMimeType: 'text/plain',
     },
@@ -101,13 +101,18 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   const rawPathKey = new URL(request.url).pathname.replace(/^\/+/, '') // strip any preceding /'s
   let pathIsEncoded = false
   let requestKey
-  if (ASSET_MANIFEST[rawPathKey]) {
+  // if options.mapRequestToAsset is explicitly passed in, always use it and assume user has own intentions
+  // otherwise handle request as normal, with default mapRequestToAsset below
+  if (options.mapRequestToAsset) {
+    requestKey = options.mapRequestToAsset(request)
+  } else if (ASSET_MANIFEST[rawPathKey]) {
     requestKey = request
   } else if (ASSET_MANIFEST[decodeURIComponent(rawPathKey)]) {
     pathIsEncoded = true;
     requestKey = request
   } else {
-    requestKey = options.mapRequestToAsset(request)
+    // use default mapRequestToAsset
+    requestKey = mapRequestToAsset(request)
   }
 
   const parsedUrl = new URL(requestKey.url)


### PR DESCRIPTION
This PR re-adds the functionality described in https://github.com/cloudflare/kv-asset-handler/issues/158.

As per the linked issue, this did used to be possible in very early versions of `kv-asset-handler`, but was broken in a recent update that added support for encoded paths and things. This was technically a breaking change, but it seems that no one else noticed. 😅

I looked at the `tests`, but didn't feel that adding this to there would serve much benefit, since these are only mocking the most simple of use-cases, and there wouldn't be a real way to "test" the actual functionality. If you've got any suggestions here, let me know. I did leave a few code comments to hopefully prevent this from becoming a regression again the future.

Technically, this once again is a breaking change, as previously the `mapRequestToAsset` function was ignored if you set it and an exact match was found in the `ASSET_MANIFEST`. I'd consider this a bug and unexpected behaviour though, and this PR fixes that.

Closes #158 