### PR TITLE
chore: repository maintenance

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "daily"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+* text eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: '12.x'
-      - run: npm install -g markdownlint-cli@0.23.2
+      - run: npm install -g markdownlint-cli@0.27.1
       - run: markdownlint '**/*.md' --ignore node_modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x, 16.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x, 14.x, 16.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: npm install, build, and test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+CHANGELOG.md
+package.json
+package-lock.json
+dist/**/*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "lf",
   "trailingComma": "all",
   "singleQuote": true,
   "semi": false,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/README.md
+++ b/README.md
@@ -14,24 +14,25 @@ For users who _do_ want to customize their assets, and want to build complex exp
 
 The Cloudflare Workers Discord server is an active place where Workers users get help, share feedback, and collaborate on making our platform better. The `#workers-sites` channel in particular is a great place to chat about `kv-asset-handler`, and building cool experiences for your users using these tools! If you have questions, want to share what you're working on, or give feedback, [join us in Discord and say hello](https://discord.gg/cloudflaredev)!
 
-  * [Installation](#installation)
-  * [Usage](#usage)
-  * [`getAssetFromKV`](#-getassetfromkv-)
-      - [Example](#example)
-    + [Return](#return)
-    + [Optional Arguments](#optional-arguments)
-      - [`mapRequestToAsset`](#-maprequesttoasset-)
-      - [Example](#example-1)
-      - [`cacheControl`](#-cachecontrol-)
-        * [`browserTTL`](#-browserttl-)
-        * [`edgeTTL`](#-edgettl-)
-        * [`bypassCache`](#-bypasscache-)
-      - [`ASSET_NAMESPACE`](#-asset-namespace-)
-      - [`ASSET_MANIFEST` (optional)](#-asset-manifest---optional-)
-- [Helper functions](#helper-functions)
-  * [`mapRequestToAsset`](#-maprequesttoasset--1)
-  * [`serveSinglePageApp`](#-servesinglepageapp-)
-- [Cache revalidation and etags](#cache-revalidation-and-etags)
+- [Installation](#installation)
+- [Usage](#usage)
+- [`getAssetFromKV`](#-getassetfromkv)
+  - [Example](#example)
+  * [Return](#return)
+  * [Optional Arguments](#optional-arguments)
+    - [`mapRequestToAsset`](#-maprequesttoasset)
+    - [Example](#example-1)
+    - [`cacheControl`](#-cachecontrol)
+      - [`browserTTL`](#-browserttl)
+      - [`edgeTTL`](#-edgettl)
+      - [`bypassCache`](#-bypasscache)
+    - [`ASSET_NAMESPACE`](#-asset-namespace)
+    - [`ASSET_MANIFEST` (optional)](#-asset-manifest---optional)
+
+* [Helper functions](#helper-functions)
+  - [`mapRequestToAsset`](#-maprequesttoasset-1)
+  - [`serveSinglePageApp`](#-servesinglepageapp)
+* [Cache revalidation and etags](#cache-revalidation-and-etags)
 
 ## Installation
 
@@ -69,7 +70,7 @@ Known errors to be thrown are:
 ```js
 import { getAssetFromKV, NotFoundError, MethodNotAllowedError } from '@cloudflare/kv-asset-handler'
 
-addEventListener('fetch', event => {
+addEventListener('fetch', (event) => {
   event.respondWith(handleEvent(event))
 })
 
@@ -83,7 +84,7 @@ async function handleEvent(event) {
       } else if (e instanceof MethodNotAllowedError) {
         // ...
       } else {
-        return new Response("An unexpected error occurred", { status: 500 })
+        return new Response('An unexpected error occurred', { status: 500 })
       }
     }
   } else return fetch(event.request)
@@ -104,7 +105,7 @@ mapRequestToAsset(Request) => Request
 
 Maps the incoming request to the value that will be looked up in Cloudflare's KV
 
-By default, mapRequestToAsset is set to the exported function [`mapRequestToAsset`](#maprequesttoasset-1).  This works for most static site generators, but you can customize this behavior by passing your own function as `mapRequestToAsset`. The function should take a `Request` object as its only argument, and return a new `Request` object with an updated path to be looked up in the asset manifest/KV.
+By default, mapRequestToAsset is set to the exported function [`mapRequestToAsset`](#maprequesttoasset-1). This works for most static site generators, but you can customize this behavior by passing your own function as `mapRequestToAsset`. The function should take a `Request` object as its only argument, and return a new `Request` object with an updated path to be looked up in the asset manifest/KV.
 
 For SPA mapping pass in the [`serveSinglePageApp`](#servesinglepageapp) function
 
@@ -219,8 +220,8 @@ All responses served from cache (including those with `cf-cache-status: MISS`) i
 
 Resources served with an `etag` allow browsers to use the `if-none-match` request header to make conditional requests for that resource in the future. This has two major benefits:
 
-* When a request's `if-none-match` value matches the `etag` of the resource in Cloudflare cache, Cloudflare will send a `304 Not Modified` response without a body, saving bandwidth.
-* Changes to a file on the server are immediately reflected in the browser - even when the cache control directive `max-age` is unexpired.
+- When a request's `if-none-match` value matches the `etag` of the resource in Cloudflare cache, Cloudflare will send a `304 Not Modified` response without a body, saving bandwidth.
+- Changes to a file on the server are immediately reflected in the browser - even when the cache control directive `max-age` is unexpired.
 
 #### Disable the `etag`
 
@@ -229,7 +230,7 @@ To turn `etags` **off**, you must bypass cache:
 ```js
 /* Turn etags off */
 let cacheControl = {
-  bypassCache: true
+  bypassCache: true,
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ava/typescript": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@ava/typescript/-/typescript-1.1.1.tgz",
+      "integrity": "sha512-KbLUAe2cWXK63WLK6LnOJonjwEDU/8MNXCOA1ooX/YFZgKRmeAD1kZu+2K0ks5fnOCEcckNQAooyBNGdZUmMQA==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -65,6 +74,12 @@
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -85,7 +100,8 @@
     "@cloudflare/workers-types": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.2.2.tgz",
-      "integrity": "sha512-kaMn2rueJ0PL1TYVGknTCh0X0x0d9G+FNXAFep7/4uqecEZoQb/63o6rOmMuiqI09zLuHV6xhKRXinokV/MY9A=="
+      "integrity": "sha512-kaMn2rueJ0PL1TYVGknTCh0X0x0d9G+FNXAFep7/4uqecEZoQb/63o6rOmMuiqI09zLuHV6xhKRXinokV/MY9A==",
+      "dev": true
     },
     "@concordance/react": {
       "version": "2.0.0",
@@ -877,9 +893,9 @@
       "dev": true
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "dev": true
     },
     "esprima": {
@@ -930,6 +946,14 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
       }
     },
     "fill-range": {
@@ -2242,14 +2266,6 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "dev": true
-        }
       }
     },
     "string-width": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1874,6 +1874,12 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true
+    },
     "pretty-ms": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,27 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
-      "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.3"
+        "@babel/highlight": "^7.12.13"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
-      "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.10.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
-      "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.3",
+        "@babel/helper-validator-identifier": "^7.14.0",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -83,9 +83,9 @@
       }
     },
     "@cloudflare/workers-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.0.0.tgz",
-      "integrity": "sha512-SFUPQzR5aV2TBLP4Re+xNX5KfAGArcRGA44OLulBDnfblEf3J+6kFvdJAQwFhFpqru3wImwT1cX0wahk6EeWTw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.2.2.tgz",
+      "integrity": "sha512-kaMn2rueJ0PL1TYVGknTCh0X0x0d9G+FNXAFep7/4uqecEZoQb/63o6rOmMuiqI09zLuHV6xhKRXinokV/MY9A=="
     },
     "@concordance/react": {
       "version": "2.0.0",
@@ -105,28 +105,28 @@
       }
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.stat": "2.0.3",
+        "@nodelib/fs.stat": "2.0.4",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
       "dev": true,
       "requires": {
-        "@nodelib/fs.scandir": "2.1.3",
+        "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
     },
@@ -145,37 +145,16 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
-    },
-    "@types/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/mime": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
-      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
-    },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -185,21 +164,21 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
+      "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
       "dev": true
     },
     "acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.0.tgz",
+      "integrity": "sha512-mjmzmv12YIG/G8JQdQuz2MUDShEJ6teYpT5bmWA4q7iwoGen8xtt3twF3OvzIUl+Q06aWIjvnwQUKvQ6TtMRjg==",
       "dev": true
     },
     "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -262,19 +241,15 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-      "dev": true,
-      "requires": {
-        "@types/color-name": "^1.1.1",
-        "color-convert": "^2.0.1"
-      }
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true
     },
     "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -321,34 +296,34 @@
       "dev": true
     },
     "ava": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ava/-/ava-3.9.0.tgz",
-      "integrity": "sha512-EnK5I/AX1U5nF4X1YG3QQYg2+jWnpvMW3z2y096DBvbwITkq9rB7Gu1j5clWcuizAJUlYbvcX6YfP+zkRFgC8Q==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/ava/-/ava-3.15.0.tgz",
+      "integrity": "sha512-HGAnk1SHPk4Sx6plFAUkzV/XC1j9+iQhOzt4vBly18/yo0AV8Oytx7mtJd/CR8igCJ5p160N/Oo/cNJi2uSeWA==",
       "dev": true,
       "requires": {
         "@concordance/react": "^2.0.0",
-        "acorn": "^7.3.1",
-        "acorn-walk": "^7.1.1",
-        "ansi-styles": "^4.2.1",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "ansi-styles": "^5.0.0",
         "arrgv": "^1.0.2",
         "arrify": "^2.0.1",
         "callsites": "^3.1.0",
         "chalk": "^4.1.0",
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.4.3",
         "chunkd": "^2.0.1",
         "ci-info": "^2.0.0",
-        "ci-parallel-vars": "^1.0.0",
+        "ci-parallel-vars": "^1.0.1",
         "clean-yaml-object": "^0.1.0",
         "cli-cursor": "^3.1.0",
         "cli-truncate": "^2.1.0",
-        "code-excerpt": "^2.1.1",
+        "code-excerpt": "^3.0.0",
         "common-path-prefix": "^3.0.0",
-        "concordance": "^5.0.0",
+        "concordance": "^5.0.1",
         "convert-source-map": "^1.7.0",
         "currently-unhandled": "^0.4.1",
-        "debug": "^4.1.1",
-        "del": "^5.1.0",
-        "emittery": "^0.7.0",
+        "debug": "^4.3.1",
+        "del": "^6.0.0",
+        "emittery": "^0.8.0",
         "equal-length": "^1.0.0",
         "figures": "^3.2.0",
         "globby": "^11.0.1",
@@ -356,81 +331,89 @@
         "import-local": "^3.0.2",
         "indent-string": "^4.0.0",
         "is-error": "^2.2.2",
-        "is-plain-object": "^3.0.0",
+        "is-plain-object": "^5.0.0",
         "is-promise": "^4.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "matcher": "^3.0.0",
         "md5-hex": "^3.0.1",
-        "mem": "^6.1.0",
-        "ms": "^2.1.2",
-        "ora": "^4.0.4",
+        "mem": "^8.0.0",
+        "ms": "^2.1.3",
+        "ora": "^5.2.0",
+        "p-event": "^4.2.0",
         "p-map": "^4.0.0",
         "picomatch": "^2.2.2",
         "pkg-conf": "^3.1.0",
         "plur": "^4.0.0",
-        "pretty-ms": "^7.0.0",
+        "pretty-ms": "^7.0.1",
         "read-pkg": "^5.2.0",
         "resolve-cwd": "^3.0.0",
         "slash": "^3.0.0",
         "source-map-support": "^0.5.19",
-        "stack-utils": "^2.0.2",
+        "stack-utils": "^2.0.3",
         "strip-ansi": "^6.0.0",
-        "supertap": "^1.0.0",
+        "supertap": "^2.0.0",
         "temp-dir": "^2.0.0",
         "trim-off-newlines": "^1.0.1",
-        "update-notifier": "^4.1.0",
+        "update-notifier": "^5.0.1",
         "write-file-atomic": "^3.0.3",
-        "yargs": "^15.3.1"
+        "yargs": "^16.2.0"
       }
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "blueimp-md5": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.16.0.tgz",
-      "integrity": "sha512-j4nzWIqEFpLSbdhUApHRGDwfXbV8ALhqOn+FY5L6XBdKPAXU9BpGgFSbDsgqogfqPPR9R2WooseWCsfhfEC6uQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q==",
       "dev": true
     },
     "boxen": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.1.tgz",
+      "integrity": "sha512-49VBlw+PrWEF51aCmy7QIteYPIFZxSpvqBdP/2itCPPlJ49kj9zg/XPRFrdkne2W+CfwXUls8exMvu1RysZpKA==",
       "dev": true,
       "requires": {
         "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^3.0.0",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^4.1.0",
-        "term-size": "^2.1.0",
-        "type-fest": "^0.8.1",
-        "widest-line": "^3.1.0"
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.0",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
       }
@@ -460,6 +443,16 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -482,9 +475,9 @@
       },
       "dependencies": {
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -505,35 +498,46 @@
       "dev": true
     },
     "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
       "dev": true
     },
     "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        }
       }
     },
     "chokidar": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
+        "readdirp": "~3.5.0"
       }
     },
     "chunkd": {
@@ -567,9 +571,9 @@
       "dev": true
     },
     "cli-boxes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
       "dev": true
     },
     "cli-cursor": {
@@ -582,9 +586,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.3.0.tgz",
-      "integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.0.tgz",
+      "integrity": "sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==",
       "dev": true
     },
     "cli-truncate": {
@@ -598,14 +602,14 @@
       }
     },
     "cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
+        "wrap-ansi": "^7.0.0"
       }
     },
     "clone": {
@@ -624,9 +628,9 @@
       }
     },
     "code-excerpt": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
-      "integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
+      "integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
       "dev": true,
       "requires": {
         "convert-to-spaces": "^1.0.1"
@@ -660,9 +664,9 @@
       "dev": true
     },
     "concordance": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.0.tgz",
-      "integrity": "sha512-stOCz9ffg0+rytwTaL2njUOIyMfANwfwmqc9Dr4vTUS/x/KkVFlWx9Zlzu6tHYtjKxxaCF/cEAZgPDac+n35sg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.4.tgz",
+      "integrity": "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==",
       "dev": true,
       "requires": {
         "date-time": "^3.1.0",
@@ -729,19 +733,21 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
-    },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -774,46 +780,19 @@
       "dev": true
     },
     "del": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
-      "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
       "dev": true,
       "requires": {
-        "globby": "^10.0.1",
-        "graceful-fs": "^4.2.2",
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
         "is-glob": "^4.0.1",
         "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.1",
-        "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "globby": {
-          "version": "10.0.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-          "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
-          "dev": true,
-          "requires": {
-            "@types/glob": "^7.1.1",
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.0.3",
-            "glob": "^7.1.3",
-            "ignore": "^5.1.1",
-            "merge2": "^1.2.3",
-            "slash": "^3.0.0"
-          }
-        },
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        }
       }
     },
     "dir-glob": {
@@ -835,9 +814,9 @@
       }
     },
     "dot-prop": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-      "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
@@ -850,9 +829,9 @@
       "dev": true
     },
     "emittery": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.0.tgz",
-      "integrity": "sha512-/kshvS+tZaggOPQDLGzXopumRRIzxciGILDlYTGIU+PmqbSfhn4wDVphFPry4H+2TNl2QxLduexPhxcWLULA5A==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
+      "integrity": "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==",
       "dev": true
     },
     "emoji-regex": {
@@ -885,6 +864,12 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
     "escape-goat": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
@@ -916,9 +901,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -930,9 +915,9 @@
       }
     },
     "fastq": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
-      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -973,11 +958,17 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -995,9 +986,9 @@
       }
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -1009,27 +1000,27 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
     },
     "global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.5"
+        "ini": "2.0.0"
       }
     },
     "globby": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
-      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -1060,10 +1051,19 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "has-flag": {
       "version": "4.0.0",
@@ -1087,6 +1087,12 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "ignore": {
@@ -1146,15 +1152,15 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true
     },
     "irregular-plurals": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
-      "integrity": "sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
+      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
       "dev": true
     },
     "is-arrayish": {
@@ -1179,6 +1185,15 @@
       "dev": true,
       "requires": {
         "ci-info": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-error": {
@@ -1209,13 +1224,13 @@
       }
     },
     "is-installed-globally": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
-      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+      "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
       "dev": true,
       "requires": {
-        "global-dirs": "^2.0.1",
-        "is-path-inside": "^3.0.1"
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
       }
     },
     "is-interactive": {
@@ -1225,9 +1240,9 @@
       "dev": true
     },
     "is-npm": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-      "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+      "integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
       "dev": true
     },
     "is-number": {
@@ -1249,19 +1264,16 @@
       "dev": true
     },
     "is-path-inside": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
     "is-plain-object": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-      "dev": true,
-      "requires": {
-        "isobject": "^4.0.0"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true
     },
     "is-promise": {
       "version": "4.0.0",
@@ -1275,16 +1287,16 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
     "is-yarn-global": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
-      "dev": true
-    },
-    "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
       "dev": true
     },
     "js-string-escape": {
@@ -1300,9 +1312,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1319,6 +1331,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "keyv": {
@@ -1413,64 +1431,13 @@
       }
     },
     "log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       }
     },
     "lowercase-keys": {
@@ -1478,6 +1445,15 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "make-dir": {
       "version": "3.1.0",
@@ -1532,19 +1508,19 @@
       }
     },
     "mem": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.0.tgz",
-      "integrity": "sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
       "dev": true,
       "requires": {
         "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.0.0"
+        "mimic-fn": "^3.1.0"
       },
       "dependencies": {
         "mimic-fn": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.0.0.tgz",
-          "integrity": "sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
           "dev": true
         }
       }
@@ -1556,19 +1532,19 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "dev": true,
       "requires": {
         "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
+        "picomatch": "^2.2.3"
       }
     },
     "mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -1598,15 +1574,9 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "normalize-package-data": {
@@ -1651,40 +1621,29 @@
       }
     },
     "onetime": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
     },
     "ora": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.4.tgz",
-      "integrity": "sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.0.tgz",
+      "integrity": "sha512-1StwyXQGoU6gdjYkyVcqOLnVlbKj+6yPNNOxJVgpt9t4eksKjiriiHuxktLYkgllwk+D6MbC4ihH84L1udRXPg==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0",
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
         "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.2.0",
+        "cli-spinners": "^2.5.0",
         "is-interactive": "^1.0.0",
-        "log-symbols": "^3.0.0",
-        "mute-stream": "0.0.8",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "wcwidth": "^1.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "p-cancelable": {
@@ -1697,6 +1656,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dev": true,
+      "requires": {
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
@@ -1724,6 +1698,15 @@
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -1793,9 +1776,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
       "dev": true
     },
     "pify": {
@@ -1881,9 +1864,9 @@
       "dev": true
     },
     "pretty-ms": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.0.tgz",
-      "integrity": "sha512-J3aPWiC5e9ZeZFuSeBraGxSkGMOvulSWsxDByOcbD1Pr75YL3LSNIKIb52WXbCLE1sS5s4inBBbryjF4Y05Ceg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
       "dev": true,
       "requires": {
         "parse-ms": "^2.1.0"
@@ -1900,13 +1883,19 @@
       }
     },
     "pupa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
-      "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
       "dev": true,
       "requires": {
         "escape-goat": "^2.0.0"
       }
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
     },
     "rc": {
       "version": "1.2.8",
@@ -1918,6 +1907,14 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+          "dev": true
+        }
       }
     },
     "read-pkg": {
@@ -1933,14 +1930,14 @@
       },
       "dependencies": {
         "parse-json": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1",
+            "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -1952,10 +1949,21 @@
         }
       }
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "readdirp": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
@@ -1971,9 +1979,9 @@
       }
     },
     "registry-auth-token": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
-      "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
+      "integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
       "dev": true,
       "requires": {
         "rc": "^1.2.8"
@@ -1994,18 +2002,13 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -2059,10 +2062,13 @@
       }
     },
     "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -2071,10 +2077,13 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -2094,10 +2103,21 @@
       }
     },
     "serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
-      "dev": true
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.13.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+          "dev": true
+        }
+      }
     },
     "service-worker-mock": {
       "version": "2.0.5",
@@ -2110,12 +2130,6 @@
         "url-search-params": "^0.10.0",
         "w3c-hr-time": "^1.0.1"
       }
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
     },
     "shelving-mock-event": {
       "version": "1.0.12",
@@ -2154,6 +2168,17 @@
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        }
       }
     },
     "source-map": {
@@ -2199,9 +2224,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
+      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
       "dev": true
     },
     "sprintf-js": {
@@ -2211,9 +2236,9 @@
       "dev": true
     },
     "stack-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
-      "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
@@ -2228,14 +2253,31 @@
       }
     },
     "string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
       }
     },
     "strip-ansi": {
@@ -2260,51 +2302,22 @@
       "dev": true
     },
     "supertap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",
-      "integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supertap/-/supertap-2.0.0.tgz",
+      "integrity": "sha512-jRzcXlCeDYvKoZGA5oRhYyR3jUIYu0enkSxtmAgHRlD7HwrovTpH4bDSi0py9FtuA8si9cW/fKommJHuaoDHJA==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "indent-string": "^3.2.0",
-        "js-yaml": "^3.10.0",
-        "serialize-error": "^2.1.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "arrify": "^2.0.1",
+        "indent-string": "^4.0.0",
+        "js-yaml": "^3.14.0",
+        "serialize-error": "^7.0.1",
+        "strip-ansi": "^6.0.0"
       }
     },
     "supports-color": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
@@ -2314,12 +2327,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
       "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-      "dev": true
-    },
-    "term-size": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
-      "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
       "dev": true
     },
     "time-zone": {
@@ -2365,9 +2372,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
-      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "unique-string": {
@@ -2380,36 +2387,25 @@
       }
     },
     "update-notifier": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.0.tgz",
-      "integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+      "integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
       "dev": true,
       "requires": {
-        "boxen": "^4.2.0",
-        "chalk": "^3.0.0",
+        "boxen": "^5.0.0",
+        "chalk": "^4.1.0",
         "configstore": "^5.0.1",
         "has-yarn": "^2.1.0",
         "import-lazy": "^2.1.0",
         "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.3.1",
-        "is-npm": "^4.0.0",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^5.0.0",
         "is-yarn-global": "^0.3.0",
-        "latest-version": "^5.0.0",
-        "pupa": "^2.0.1",
+        "latest-version": "^5.1.0",
+        "pupa": "^2.1.1",
+        "semver": "^7.3.4",
         "semver-diff": "^3.1.1",
         "xdg-basedir": "^4.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        }
       }
     },
     "urijs": {
@@ -2431,6 +2427,12 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/url-search-params/-/url-search-params-0.10.2.tgz",
       "integrity": "sha512-d6GYsr992Bo9rzTZFc9BUw3UFAAg3prE9JGVBgW2TLTbI3rSvg4VDa0BFXHMzKkWbAuhrmaFWpucpRJl+3W7Jg==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -2467,12 +2469,6 @@
       "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
       "dev": true
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
     "widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
@@ -2483,14 +2479,25 @@
       }
     },
     "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        }
       }
     },
     "wrappy": {
@@ -2518,39 +2525,37 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "requires": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
         "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.1"
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
       }
     },
     "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
     "wrangler",
     "assets"
   ],
+  "files": [
+    "src",
+    "dist",
+    "LICENSE_APACHE",
+    "LICENSE_MIT"
+  ],
   "author": "wrangler@cloudflare.com",
   "license": "MIT OR Apache-2.0",
   "bugs": {
@@ -29,10 +35,11 @@
   },
   "homepage": "https://github.com/cloudflare/kv-asset-handler#readme",
   "dependencies": {
-    "@cloudflare/workers-types": "^2.2.2",
     "mime": "^2.5.2"
   },
   "devDependencies": {
+    "@ava/typescript": "^1.1.1",
+    "@cloudflare/workers-types": "^2.2.2",
     "@types/mime": "^2.0.3",
     "@types/node": "^15.3.0",
     "ava": "^3.15.0",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,15 @@
   },
   "homepage": "https://github.com/cloudflare/kv-asset-handler#readme",
   "dependencies": {
-    "@cloudflare/workers-types": "^2.0.0",
-    "@types/mime": "^2.0.2",
-    "mime": "^2.4.6"
+    "@cloudflare/workers-types": "^2.2.2",
+    "mime": "^2.5.2"
   },
   "devDependencies": {
-    "ava": "^3.9.0",
+    "@types/mime": "^2.0.3",
+    "@types/node": "^15.3.0",
+    "ava": "^3.15.0",
     "prettier": "^2.3.0",
     "service-worker-mock": "^2.0.5",
-    "typescript": "^3.9.5"
+    "typescript": "^4.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   "scripts": {
     "prepack": "npm run build",
     "build": "tsc -d",
-    "format": "prettier --write '**/*.js'",
+    "format": "prettier --write \"**/*.{js,ts,json,md}\"",
     "pretest": "npm run build",
     "test": "ava dist/test/*.js --verbose"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cloudflare/workers-site-npm-pkg.git"
+    "url": "git+https://github.com/cloudflare/kv-asset-handler.git"
   },
   "keywords": [
     "kv",
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "ava": "^3.9.0",
+    "prettier": "^2.3.0",
     "service-worker-mock": "^2.0.5",
     "typescript": "^3.9.5"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,9 +85,10 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
 
   const request = event.request
   const ASSET_NAMESPACE = options.ASSET_NAMESPACE
-  const ASSET_MANIFEST = typeof (options.ASSET_MANIFEST) === 'string'
-    ? JSON.parse(options.ASSET_MANIFEST)
-    : options.ASSET_MANIFEST
+  const ASSET_MANIFEST =
+    typeof options.ASSET_MANIFEST === 'string'
+      ? JSON.parse(options.ASSET_MANIFEST)
+      : options.ASSET_MANIFEST
 
   if (typeof ASSET_NAMESPACE === 'undefined') {
     throw new InternalError(`there is no KV namespace bound to the script`)
@@ -103,13 +104,13 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   } else if (ASSET_MANIFEST[rawPathKey]) {
     requestKey = request
   } else if (ASSET_MANIFEST[decodeURIComponent(rawPathKey)]) {
-    pathIsEncoded = true;
+    pathIsEncoded = true
     requestKey = request
   } else {
     const mappedRequest = mapRequestToAsset(request)
     const mappedRawPathKey = new URL(mappedRequest.url).pathname.replace(/^\/+/, '')
     if (ASSET_MANIFEST[decodeURIComponent(mappedRawPathKey)]) {
-      pathIsEncoded = true;
+      pathIsEncoded = true
       requestKey = mappedRequest
     } else {
       // use default mapRequestToAsset
@@ -132,7 +133,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   const cache = caches.default
   let mimeType = mime.getType(pathKey) || options.defaultMimeType
   if (mimeType.startsWith('text') || mimeType === 'application/javascript') {
-      mimeType += '; charset=utf-8'
+    mimeType += '; charset=utf-8'
   }
 
   let shouldEdgeCache = false // false if storing in KV by raw file path i.e. no hash
@@ -197,11 +198,10 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
       request.headers.get('if-none-match') === `${pathKey}`,
     ].every(Boolean)
 
-
     if (shouldRevalidate) {
       // fixes issue #118
       if (response.body && 'cancel' in Object.getPrototypeOf(response.body)) {
-        response.body.cancel();
+        response.body.cancel()
         console.log('Body exists and environment supports readable streams. Body cancelled')
       } else {
         console.log('Environment doesnt support readable streams')
@@ -219,7 +219,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
       let opts = {
         headers,
         status: 0,
-        statusText: ''
+        statusText: '',
       }
       if (response.status) {
         opts.status = response.status

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -47,29 +47,29 @@ export const mockManifest = () => {
     'index.html': `index.${HASH}.html`,
     'sub/blah.png': `sub/blah.${HASH}.png`,
     'sub/index.html': `sub/index.${HASH}.html`,
-    'client': `client.${HASH}`,
+    client: `client.${HASH}`,
     'client/index.html': `client.${HASH}`,
-    '你好/index.html': `你好/index.${HASH}.html`
+    '你好/index.html': `你好/index.${HASH}.html`,
   })
 }
 
 let cacheStore: any = new Map()
 interface CacheKey {
-  url:object;
-  headers:object
+  url: object
+  headers: object
 }
 export const mockCaches = () => {
   return {
     default: {
-      async match (key: any) {
+      async match(key: any) {
         let cacheKey: CacheKey = {
           url: key.url,
-          headers: {}
+          headers: {},
         }
         let response
         if (key.headers.has('if-none-match')) {
           cacheKey.headers = {
-            'etag': key.headers.get('if-none-match')
+            etag: key.headers.get('if-none-match'),
           }
           response = cacheStore.get(JSON.stringify(cacheKey))
         } else {
@@ -87,7 +87,10 @@ export const mockCaches = () => {
           // The Range request header triggers the response header Content-Range ...
           const range = key.headers.get('range')
           if (range) {
-            response.headers.set('content-range', `bytes ${range.split('=').pop()}/${response.headers.get('content-length')}`)
+            response.headers.set(
+              'content-range',
+              `bytes ${range.split('=').pop()}/${response.headers.get('content-length')}`,
+            )
           }
           // ... which we are using in this repository to set status 206
           if (response.headers.has('content-range')) {
@@ -98,16 +101,16 @@ export const mockCaches = () => {
         }
         return response
       },
-      async put (key: any, val: Response) {
+      async put(key: any, val: Response) {
         let headers = new Headers(val.headers)
         let body = await val.text()
         let resp = new Response(body, { headers })
-        headers.set('content-length', (body.length).toString())
+        headers.set('content-length', body.length.toString())
         let cacheKey: CacheKey = {
           url: key.url,
           headers: {
-            'etag': val.headers.get('etag')
-          }
+            etag: val.headers.get('etag'),
+          },
         }
         return cacheStore.set(JSON.stringify(cacheKey), resp)
       },
@@ -122,5 +125,5 @@ export function mockGlobal() {
   Object.assign(global, { caches: mockCaches() })
 }
 export const sleep = (milliseconds: number) => {
-  return new Promise(resolve => setTimeout(resolve, milliseconds))
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -3,7 +3,7 @@ import { mockGlobal, getEvent, sleep, mockKV, mockManifest } from '../mocks'
 import { getAssetFromKV, mapRequestToAsset } from '../index'
 import { KVError } from '../types'
 
-test('getAssetFromKV return correct val from KV and default caching', async t => {
+test('getAssetFromKV return correct val from KV and default caching', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/key1.txt'))
   const res = await getAssetFromKV(event)
@@ -17,14 +17,14 @@ test('getAssetFromKV return correct val from KV and default caching', async t =>
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV evaluated the file matching the extensionless path first /client/ -> client', async t => {
+test('getAssetFromKV evaluated the file matching the extensionless path first /client/ -> client', async (t) => {
   mockGlobal()
   const event = getEvent(new Request(`https://foo.com/client/`))
   const res = await getAssetFromKV(event)
   t.is(await res.text(), 'important file')
   t.true(res.headers.get('content-type').includes('text'))
 })
-test('getAssetFromKV evaluated the file matching the extensionless path first /client -> client', async t => {
+test('getAssetFromKV evaluated the file matching the extensionless path first /client -> client', async (t) => {
   mockGlobal()
   const event = getEvent(new Request(`https://foo.com/client`))
   const res = await getAssetFromKV(event)
@@ -32,7 +32,7 @@ test('getAssetFromKV evaluated the file matching the extensionless path first /c
   t.true(res.headers.get('content-type').includes('text'))
 })
 
-test('getAssetFromKV if not in asset manifest still returns nohash.txt', async t => {
+test('getAssetFromKV if not in asset manifest still returns nohash.txt', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/nohash.txt'))
   const res = await getAssetFromKV(event)
@@ -45,14 +45,14 @@ test('getAssetFromKV if not in asset manifest still returns nohash.txt', async t
   }
 })
 
-test('getAssetFromKV if no asset manifest /client -> client fails', async t => {
+test('getAssetFromKV if no asset manifest /client -> client fails', async (t) => {
   mockGlobal()
   const event = getEvent(new Request(`https://foo.com/client`))
   const error: KVError = await t.throwsAsync(getAssetFromKV(event, { ASSET_MANIFEST: {} }))
   t.is(error.status, 404)
 })
 
-test('getAssetFromKV if sub/ -> sub/index.html served', async t => {
+test('getAssetFromKV if sub/ -> sub/index.html served', async (t) => {
   mockGlobal()
   const event = getEvent(new Request(`https://foo.com/sub`))
   const res = await getAssetFromKV(event)
@@ -63,7 +63,7 @@ test('getAssetFromKV if sub/ -> sub/index.html served', async t => {
   }
 })
 
-test('getAssetFromKV gets index.html by default for / requests', async t => {
+test('getAssetFromKV gets index.html by default for / requests', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))
   const res = await getAssetFromKV(event)
@@ -76,7 +76,7 @@ test('getAssetFromKV gets index.html by default for / requests', async t => {
   }
 })
 
-test('getAssetFromKV non ASCII path support', async t => {
+test('getAssetFromKV non ASCII path support', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/测试.html'))
   const res = await getAssetFromKV(event)
@@ -88,7 +88,7 @@ test('getAssetFromKV non ASCII path support', async t => {
   }
 })
 
-test('getAssetFromKV supports browser percent encoded URLs', async t => {
+test('getAssetFromKV supports browser percent encoded URLs', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://example.com/%not-really-percent-encoded.html'))
   const res = await getAssetFromKV(event)
@@ -100,7 +100,7 @@ test('getAssetFromKV supports browser percent encoded URLs', async t => {
   }
 })
 
-test('getAssetFromKV supports user percent encoded URLs', async t => {
+test('getAssetFromKV supports user percent encoded URLs', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/%2F.html'))
   const res = await getAssetFromKV(event)
@@ -112,7 +112,7 @@ test('getAssetFromKV supports user percent encoded URLs', async t => {
   }
 })
 
-test('getAssetFromKV only decode URL when necessary', async t => {
+test('getAssetFromKV only decode URL when necessary', async (t) => {
   mockGlobal()
   const event1 = getEvent(new Request('https://blah.com/%E4%BD%A0%E5%A5%BD.html'))
   const event2 = getEvent(new Request('https://blah.com/你好.html'))
@@ -127,7 +127,7 @@ test('getAssetFromKV only decode URL when necessary', async t => {
   }
 })
 
-test('getAssetFromKV Support for user decode url path', async t => {
+test('getAssetFromKV Support for user decode url path', async (t) => {
   mockGlobal()
   const event1 = getEvent(new Request('https://blah.com/%E4%BD%A0%E5%A5%BD/'))
   const event2 = getEvent(new Request('https://blah.com/你好/'))
@@ -142,7 +142,7 @@ test('getAssetFromKV Support for user decode url path', async t => {
   }
 })
 
-test('getAssetFromKV custom key modifier', async t => {
+test('getAssetFromKV custom key modifier', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/docs/sub/blah.png'))
 
@@ -163,7 +163,7 @@ test('getAssetFromKV custom key modifier', async t => {
   }
 })
 
-test('getAssetFromKV when setting browser caching', async t => {
+test('getAssetFromKV when setting browser caching', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))
 
@@ -176,7 +176,7 @@ test('getAssetFromKV when setting browser caching', async t => {
   }
 })
 
-test('getAssetFromKV when setting custom cache setting', async t => {
+test('getAssetFromKV when setting custom cache setting', async (t) => {
   mockGlobal()
   const event1 = getEvent(new Request('https://blah.com/'))
   const event2 = getEvent(new Request('https://blah.com/key1.png?blah=34'))
@@ -204,16 +204,18 @@ test('getAssetFromKV when setting custom cache setting', async t => {
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV caches on two sequential requests', async t => {
+test('getAssetFromKV caches on two sequential requests', async (t) => {
   mockGlobal()
   const resourceKey = 'cache.html'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
   const event1 = getEvent(new Request(`https://blah.com/${resourceKey}`))
-  const event2 = getEvent(new Request(`https://blah.com/${resourceKey}`, {
-    headers: {
-      'if-none-match': resourceVersion
-    }
-  }))
+  const event2 = getEvent(
+    new Request(`https://blah.com/${resourceKey}`, {
+      headers: {
+        'if-none-match': resourceVersion,
+      },
+    }),
+  )
 
   const res1 = await getAssetFromKV(event1, { cacheControl: { edgeTTL: 720, browserTTL: 720 } })
   await sleep(1)
@@ -227,16 +229,18 @@ test('getAssetFromKV caches on two sequential requests', async t => {
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV does not store max-age on two sequential requests', async t => {
+test('getAssetFromKV does not store max-age on two sequential requests', async (t) => {
   mockGlobal()
   const resourceKey = 'cache.html'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
   const event1 = getEvent(new Request(`https://blah.com/${resourceKey}`))
-  const event2 = getEvent(new Request(`https://blah.com/${resourceKey}`, {
-    headers: {
-      'if-none-match': resourceVersion
-    }
-  }))
+  const event2 = getEvent(
+    new Request(`https://blah.com/${resourceKey}`, {
+      headers: {
+        'if-none-match': resourceVersion,
+      },
+    }),
+  )
 
   const res1 = await getAssetFromKV(event1, { cacheControl: { edgeTTL: 720 } })
   await sleep(100)
@@ -252,7 +256,7 @@ test('getAssetFromKV does not store max-age on two sequential requests', async t
   }
 })
 
-test('getAssetFromKV does not cache on Cloudflare when bypass cache set', async t => {
+test('getAssetFromKV does not cache on Cloudflare when bypass cache set', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))
 
@@ -266,7 +270,7 @@ test('getAssetFromKV does not cache on Cloudflare when bypass cache set', async 
   }
 })
 
-test('getAssetFromKV with no trailing slash on root', async t => {
+test('getAssetFromKV with no trailing slash on root', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com'))
   const res = await getAssetFromKV(event)
@@ -277,7 +281,7 @@ test('getAssetFromKV with no trailing slash on root', async t => {
   }
 })
 
-test('getAssetFromKV with no trailing slash on a subdirectory', async t => {
+test('getAssetFromKV with no trailing slash on a subdirectory', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/sub/blah.png'))
   const res = await getAssetFromKV(event)
@@ -288,13 +292,13 @@ test('getAssetFromKV with no trailing slash on a subdirectory', async t => {
   }
 })
 
-test('getAssetFromKV no result throws an error', async t => {
+test('getAssetFromKV no result throws an error', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/random'))
   const error: KVError = await t.throwsAsync(getAssetFromKV(event))
   t.is(error.status, 404)
 })
-test('getAssetFromKV TTls set to null should not cache on browser or edge', async t => {
+test('getAssetFromKV TTls set to null should not cache on browser or edge', async (t) => {
   mockGlobal()
   const event = getEvent(new Request('https://blah.com/'))
 
@@ -311,7 +315,7 @@ test('getAssetFromKV TTls set to null should not cache on browser or edge', asyn
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV passing in a custom NAMESPACE serves correct asset', async t => {
+test('getAssetFromKV passing in a custom NAMESPACE serves correct asset', async (t) => {
   mockGlobal()
   let CUSTOM_NAMESPACE = mockKV({
     'key1.123HASHBROWN.txt': 'val1',
@@ -326,7 +330,7 @@ test('getAssetFromKV passing in a custom NAMESPACE serves correct asset', async 
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV when custom namespace without the asset should fail', async t => {
+test('getAssetFromKV when custom namespace without the asset should fail', async (t) => {
   mockGlobal()
   let CUSTOM_NAMESPACE = mockKV({
     'key5.123HASHBROWN.txt': 'customvalu',
@@ -338,7 +342,7 @@ test('getAssetFromKV when custom namespace without the asset should fail', async
   )
   t.is(error.status, 404)
 })
-test('getAssetFromKV when namespace not bound fails', async t => {
+test('getAssetFromKV when namespace not bound fails', async (t) => {
   mockGlobal()
   var MY_CUSTOM_NAMESPACE = undefined
   Object.assign(global, { MY_CUSTOM_NAMESPACE })
@@ -350,16 +354,18 @@ test('getAssetFromKV when namespace not bound fails', async t => {
   t.is(error.status, 500)
 })
 
-test('getAssetFromKV when if-none-match === etag and etag === pathKey in manifest, should revalidate', async t => {
+test('getAssetFromKV when if-none-match === etag and etag === pathKey in manifest, should revalidate', async (t) => {
   mockGlobal()
   const resourceKey = 'key1.png'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
   const event1 = getEvent(new Request(`https://blah.com/${resourceKey}`))
-  const event2 = getEvent(new Request(`https://blah.com/${resourceKey}`, {
-    headers: {
-      'if-none-match': resourceVersion
-    }
-  }))
+  const event2 = getEvent(
+    new Request(`https://blah.com/${resourceKey}`, {
+      headers: {
+        'if-none-match': resourceVersion,
+      },
+    }),
+  )
 
   const res1 = await getAssetFromKV(event1, { cacheControl: { edgeTTL: 720 } })
   await sleep(100)
@@ -374,19 +380,19 @@ test('getAssetFromKV when if-none-match === etag and etag === pathKey in manifes
   }
 })
 
-test('getAssetFromKV when etag and if-none-match are present but if-none-match !== etag, should bypass cache', async t => {
+test('getAssetFromKV when etag and if-none-match are present but if-none-match !== etag, should bypass cache', async (t) => {
   mockGlobal()
   const resourceKey = 'key1.png'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
   const req1 = new Request(`https://blah.com/${resourceKey}`, {
     headers: {
-      'if-none-match': resourceVersion
-    }
+      'if-none-match': resourceVersion,
+    },
   })
   const req2 = new Request(`https://blah.com/${resourceKey}`, {
     headers: {
-      'if-none-match': resourceVersion + "another-version"
-    }
+      'if-none-match': resourceVersion + 'another-version',
+    },
   })
   const event = getEvent(req1)
   const event2 = getEvent(req2)
@@ -403,7 +409,7 @@ test('getAssetFromKV when etag and if-none-match are present but if-none-match !
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV if-none-match not sent but resource in cache, should return hit', async t => {
+test('getAssetFromKV if-none-match not sent but resource in cache, should return hit', async (t) => {
   const resourceKey = 'cache.html'
   const event = getEvent(new Request(`https://blah.com/${resourceKey}`))
   const res1 = await getAssetFromKV(event, { cacheControl: { edgeTTL: 720 } })
@@ -418,10 +424,12 @@ test('getAssetFromKV if-none-match not sent but resource in cache, should return
   }
 })
 
-test('getAssetFromKV if range request submitted and resource in cache, request fulfilled', async t => {
+test('getAssetFromKV if range request submitted and resource in cache, request fulfilled', async (t) => {
   const resourceKey = 'cache.html'
   const event1 = getEvent(new Request(`https://blah.com/${resourceKey}`))
-  const event2 = getEvent(new Request(`https://blah.com/${resourceKey}`, { headers: { 'range': 'bytes=0-10'}}))
+  const event2 = getEvent(
+    new Request(`https://blah.com/${resourceKey}`, { headers: { range: 'bytes=0-10' } }),
+  )
   const res1 = await getAssetFromKV(event1, { cacheControl: { edgeTTL: 720 } })
   await res1
   await sleep(2)

--- a/src/test/mapRequestToAsset.ts
+++ b/src/test/mapRequestToAsset.ts
@@ -2,7 +2,7 @@ import test from 'ava'
 import { mockGlobal } from '../mocks'
 import { mapRequestToAsset } from '../index'
 
-test('mapRequestToAsset() correctly changes /about -> /about/index.html', async t => {
+test('mapRequestToAsset() correctly changes /about -> /about/index.html', async (t) => {
   mockGlobal()
   let path = '/about'
   let request = new Request(`https://foo.com${path}`)
@@ -10,14 +10,14 @@ test('mapRequestToAsset() correctly changes /about -> /about/index.html', async 
   t.is(newRequest.url, request.url + '/index.html')
 })
 
-test('mapRequestToAsset() correctly changes /about/ -> /about/index.html', async t => {
+test('mapRequestToAsset() correctly changes /about/ -> /about/index.html', async (t) => {
   let path = '/about/'
   let request = new Request(`https://foo.com${path}`)
   let newRequest = mapRequestToAsset(request)
   t.is(newRequest.url, request.url + 'index.html')
 })
 
-test('mapRequestToAsset() correctly changes /about.me/ -> /about.me/index.html', async t => {
+test('mapRequestToAsset() correctly changes /about.me/ -> /about.me/index.html', async (t) => {
   let path = '/about.me/'
   let request = new Request(`https://foo.com${path}`)
   let newRequest = mapRequestToAsset(request)

--- a/src/test/serveSinglePageApp.ts
+++ b/src/test/serveSinglePageApp.ts
@@ -11,7 +11,7 @@ function testRequest(path: string) {
   return request
 }
 
-test('serveSinglePageApp returns root asset path when request path ends in .html', async t => {
+test('serveSinglePageApp returns root asset path when request path ends in .html', async (t) => {
   let path = '/foo/thing.html'
   let request = testRequest(path)
 
@@ -21,7 +21,7 @@ test('serveSinglePageApp returns root asset path when request path ends in .html
   t.deepEqual(expected_request, actual_request)
 })
 
-test('serveSinglePageApp returns root asset path when request path does not have extension', async t => {
+test('serveSinglePageApp returns root asset path when request path does not have extension', async (t) => {
   let path = '/foo/thing'
   let request = testRequest(path)
 
@@ -31,7 +31,7 @@ test('serveSinglePageApp returns root asset path when request path does not have
   t.deepEqual(expected_request, actual_request)
 })
 
-test('serveSinglePageApp returns requested asset when request path has non-html extension', async t => {
+test('serveSinglePageApp returns requested asset when request path has non-html extension', async (t) => {
   let path = '/foo/thing.js'
   let request = testRequest(path)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type Options = {
   cacheControl: ((req: Request) => Partial<CacheControl>) | Partial<CacheControl>
   ASSET_NAMESPACE: any
   ASSET_MANIFEST: Object | string
-  mapRequestToAsset: (req: Request) => Request,
+  mapRequestToAsset: (req: Request) => Request
   defaultMimeType: string
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,11 @@
   "compilerOptions": {
     "outDir": "./dist",
     "noImplicitAny": true,
-    "target": "es5",
+    "target": "es6",
     "allowJs": false,
-    "lib": ["WebWorker", "ES5", "ScriptHost"]
+    "lib": ["WebWorker", "ES5", "ScriptHost"],
+    "module": "commonjs",
+    "moduleResolution": "node"
   },
   "include": ["./src/*.ts", "./src/**/*.ts", "./test/**/*.ts", "./test/*.ts", "./src/types.d.ts"],
   "exclude": ["node_modules/", "dist/"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "noImplicitAny": true,
     "target": "es5",
     "allowJs": false,
-    "lib": ["webworker"]
+    "lib": ["WebWorker", "ES5", "ScriptHost"]
   },
   "include": ["./src/*.ts", "./src/**/*.ts", "./test/**/*.ts", "./test/*.ts", "./src/types.d.ts"],
   "exclude": ["node_modules/", "dist/"]


### PR DESCRIPTION
This PR does some repo maintenance in terms of code quality, dependencies, testing, and typescript.

## TypeScript
- Tweaks target to `es6` over `es5`. This reduces a few unnecessary polyfills that are not required in a Workers environment, such as generators. We should look at setting this even higher in future with ESM support and `async/await`.
- With this tweak, expanded the config to build a similar bundle as before with applicable `module` and `moduleResolution`. 

## Code Quality
- Re-enables `prettier` properly (by adding to `devDependencies`) and fixes the `npm` script that runs this
- With above, runs `prettier` on existing files, and tweaks a few minor formatting things
	- The prettier config already present in the repo was used, with one tweak to mimic `cloudflare-docs-engine`. It was run on all existing files

## Dependencies
- Updates GitHub Actions workflows to latest versions for slightly faster runs
- Bumps all dependency versions
- Moves all `@types` dependencies to `devDependencies`, as these do not need to be in the production install tree
- Update `dependabot` config to newest version

## Testing
- Removes Node.js 8.x from testing. This version went EOL in 2019, and isn't supported by a few of the dependencies we use now. Technically a breaking change, but not one I think that's impacting, since this library isn't really "used" in a Node environment anyway.
- Adds Node.js 14 and 16 to tests. Wwe should probably look at dropping Node < 12 support at some point, since these versions [are now EOL](https://nodejs.org/en/about/releases/)
- Tweaked `ava` configuration for newer and better TypeScript support with `@ava/typescript`

## Publishing
- Implements some of the suggestions from #156:
	- Specifies a `files` option in `package.json` to only publish needed files to NPM. (No `.github`, `.dependabot`, etc. configuration) 

## Docs

- Fixes table of contents anchor links in the README. As a side note, this is now built-in to Github by default for any markdown files. We could probably remove this section in entirely and simplify the README.


Let me know if I can provide any more insight. I'm excited to see this repository getting maintained again! 😃