### PR TITLE
ci: tweak GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,9 @@
-name: Lint Markdown
+name: Lint
 
 on: [push, pull_request]
 
 jobs:
-  test:
+  markdown:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -12,4 +12,23 @@ jobs:
         with:
           node-version: '12.x'
       - run: npm install -g markdownlint-cli@0.27.1
-      - run: markdownlint '**/*.md' --ignore node_modules
+      - run: npm run lint:markdown
+
+  prettier:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+      - name: Restore NPM cache
+        uses: actions/cache@v2
+        continue-on-error: true
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run lint:code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run npm tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -19,7 +19,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: npm install, build, and test
         run: |
-          npm install
+          npm ci
           npm run build --if-present
           npm test
         env:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "tsc -d",
     "format": "prettier --write \"**/*.{js,ts,json,md}\"",
     "pretest": "npm run build",
+    "lint:code": "prettier --check \"**/*.{js,ts,json,md}\"",
+    "lint:markdown": "markdownlint \"**/*.md\" --ignore node_modules",
     "test": "ava dist/test/*.js --verbose"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ function assignOptions(options?: Partial<Options>): Options {
  * @param {Request} request incoming request
  */
 const mapRequestToAsset = (request: Request, options?: Partial<Options>) => {
-  options = assignOptions(options);
+  options = assignOptions(options)
 
   const parsedUrl = new URL(request.url)
   let pathname = parsedUrl.pathname
@@ -59,7 +59,7 @@ const mapRequestToAsset = (request: Request, options?: Partial<Options>) => {
  * @param {Request} request incoming request
  */
 function serveSinglePageApp(request: Request, options?: Partial<Options>): Request {
-  options = assignOptions(options);
+  options = assignOptions(options)
 
   // First apply the default handler, which already has logic to detect
   // paths that should map to HTML files.

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -26,7 +26,7 @@ const store: any = {
   'sub/index.123HASHBROWN.html': 'picturedis',
   'client.123HASHBROWN': 'important file',
   'client.123HASHBROWN/index.html': 'Im here but serve my big bro above',
-  '你好/index.123HASHBROWN.html': 'My path is non-ascii'
+  '你好/index.123HASHBROWN.html': 'My path is non-ascii',
 }
 export const mockKV = (store: any) => {
   return {
@@ -49,7 +49,7 @@ export const mockManifest = () => {
     'sub/index.html': `sub/index.${HASH}.html`,
     client: `client.${HASH}`,
     'client/index.html': `client.${HASH}`,
-    '你好/index.html': `你好/index.${HASH}.html`
+    '你好/index.html': `你好/index.${HASH}.html`,
   })
 }
 
@@ -113,8 +113,8 @@ export const mockCaches = () => {
         let cacheKey: CacheKey = {
           url: key.url,
           headers: {
-            'etag': `"${url.pathname.replace('/', '')}"`
-          }
+            etag: `"${url.pathname.replace('/', '')}"`,
+          },
         }
         cacheStore.set(JSON.stringify(cacheKey), resNoBody)
         cacheKey.headers = {}

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -354,7 +354,7 @@ test('getAssetFromKV when namespace not bound fails', async (t) => {
   t.is(error.status, 500)
 })
 
-test('getAssetFromKV when if-none-match === active resource version, should revalidate', async t => {
+test('getAssetFromKV when if-none-match === active resource version, should revalidate', async (t) => {
   mockGlobal()
   const resourceKey = 'key1.png'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
@@ -379,7 +379,7 @@ test('getAssetFromKV when if-none-match === active resource version, should reva
   }
 })
 
-test('getAssetFromKV when if-none-match equals etag of stale resource then should bypass cache', async t => {
+test('getAssetFromKV when if-none-match equals etag of stale resource then should bypass cache', async (t) => {
   mockGlobal()
   const resourceKey = 'key1.png'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
@@ -408,7 +408,7 @@ test('getAssetFromKV when if-none-match equals etag of stale resource then shoul
     t.fail('Response was undefined')
   }
 })
-test('getAssetFromKV when resource in cache, etag should be weakened before returned to eyeball', async t => {
+test('getAssetFromKV when resource in cache, etag should be weakened before returned to eyeball', async (t) => {
   mockGlobal()
   const resourceKey = 'key1.png'
   const resourceVersion = JSON.parse(mockManifest())[resourceKey]
@@ -428,7 +428,7 @@ test('getAssetFromKV when resource in cache, etag should be weakened before retu
   }
 })
 
-test('getAssetFromKV if-none-match not sent but resource in cache, should return cache hit 200 OK', async t => {
+test('getAssetFromKV if-none-match not sent but resource in cache, should return cache hit 200 OK', async (t) => {
   const resourceKey = 'cache.html'
   const event = getEvent(new Request(`https://blah.com/${resourceKey}`))
   const res1 = await getAssetFromKV(event, { cacheControl: { edgeTTL: 720 } })

--- a/src/test/mapRequestToAsset.ts
+++ b/src/test/mapRequestToAsset.ts
@@ -28,6 +28,6 @@ test('mapRequestToAsset() correctly changes /about -> /about/default.html', asyn
   mockGlobal()
   let path = '/about'
   let request = new Request(`https://foo.com${path}`)
-  let newRequest = mapRequestToAsset(request, {defaultDocument: 'default.html'})
+  let newRequest = mapRequestToAsset(request, { defaultDocument: 'default.html' })
   t.is(newRequest.url, request.url + '/default.html')
 })


### PR DESCRIPTION
As previously discussed sets the `test` workflow to run in PRs, and adds a Prettier job to the linting workflow. Also uses `npm ci` where appropriate with `actions/cache` to improve install speed.

Includes updated files from other PRs to adhere to Prettier rules.