### PR TITLE
perf: only parse `ASSET_MANIFEST` once on startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,11 @@ const parseStringAsObject = <T>(maybeString: string | T): T =>
   typeof maybeString === 'string' ? (JSON.parse(maybeString) as T) : maybeString
 
 const getAssetFromKVDefaultOptions: Partial<Options> = {
-  ASSET_NAMESPACE: __STATIC_CONTENT,
-  ASSET_MANIFEST: parseStringAsObject<AssetManifestType>(__STATIC_CONTENT_MANIFEST),
+  ASSET_NAMESPACE: typeof __STATIC_CONTENT !== 'undefined' ? __STATIC_CONTENT : undefined,
+  ASSET_MANIFEST:
+    typeof __STATIC_CONTENT_MANIFEST !== 'undefined'
+      ? parseStringAsObject<AssetManifestType>(__STATIC_CONTENT_MANIFEST)
+      : undefined,
   cacheControl: defaultCacheControl,
   defaultMimeType: 'text/plain',
   defaultDocument: 'index.html',

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -129,12 +129,20 @@ export const mockCaches = () => {
   }
 }
 
-export function mockGlobal() {
+// mocks functionality used inside worker request
+export function mockRequestScope() {
   Object.assign(global, makeServiceWorkerEnv())
   Object.assign(global, { __STATIC_CONTENT_MANIFEST: mockManifest() })
   Object.assign(global, { __STATIC_CONTENT: mockKV(store) })
   Object.assign(global, { caches: mockCaches() })
 }
+
+// mocks functionality used on global isolate scope. such as the KV namespace bind
+export function mockGlobalScope() {
+  Object.assign(global, { __STATIC_CONTENT_MANIFEST: mockManifest() })
+  Object.assign(global, { __STATIC_CONTENT: mockKV(store) })
+}
+
 export const sleep = (milliseconds: number) => {
   return new Promise((resolve) => setTimeout(resolve, milliseconds))
 }

--- a/src/test/getAssetFromKV.ts
+++ b/src/test/getAssetFromKV.ts
@@ -167,7 +167,7 @@ test('getAssetFromKV custom key modifier', async (t) => {
 
 test('getAssetFromKV request override with existing manifest file', async (t) => {
   // see https://github.com/cloudflare/kv-asset-handler/pull/159 for more info
-  mockGlobal()
+  mockRequestScope()
   const event = getEvent(new Request('https://blah.com/image.png')) // real file in manifest
 
   const customRequestMapper = (request: Request) => {

--- a/src/test/mapRequestToAsset.ts
+++ b/src/test/mapRequestToAsset.ts
@@ -1,9 +1,11 @@
 import test from 'ava'
-import { mockGlobal } from '../mocks'
+import { mockRequestScope, mockGlobalScope } from '../mocks'
+mockGlobalScope()
+
 import { mapRequestToAsset } from '../index'
 
 test('mapRequestToAsset() correctly changes /about -> /about/index.html', async (t) => {
-  mockGlobal()
+  mockRequestScope()
   let path = '/about'
   let request = new Request(`https://foo.com${path}`)
   let newRequest = mapRequestToAsset(request)
@@ -11,6 +13,7 @@ test('mapRequestToAsset() correctly changes /about -> /about/index.html', async 
 })
 
 test('mapRequestToAsset() correctly changes /about/ -> /about/index.html', async (t) => {
+  mockRequestScope()
   let path = '/about/'
   let request = new Request(`https://foo.com${path}`)
   let newRequest = mapRequestToAsset(request)
@@ -18,6 +21,7 @@ test('mapRequestToAsset() correctly changes /about/ -> /about/index.html', async
 })
 
 test('mapRequestToAsset() correctly changes /about.me/ -> /about.me/index.html', async (t) => {
+  mockRequestScope()
   let path = '/about.me/'
   let request = new Request(`https://foo.com${path}`)
   let newRequest = mapRequestToAsset(request)
@@ -25,7 +29,7 @@ test('mapRequestToAsset() correctly changes /about.me/ -> /about.me/index.html',
 })
 
 test('mapRequestToAsset() correctly changes /about -> /about/default.html', async (t) => {
-  mockGlobal()
+  mockRequestScope()
   let path = '/about'
   let request = new Request(`https://foo.com${path}`)
   let newRequest = mapRequestToAsset(request, { defaultDocument: 'default.html' })

--- a/src/test/serveSinglePageApp.ts
+++ b/src/test/serveSinglePageApp.ts
@@ -1,9 +1,11 @@
 import test from 'ava'
-import { mockGlobal } from '../mocks'
+import { mockRequestScope, mockGlobalScope } from '../mocks'
+mockGlobalScope()
+
 import { serveSinglePageApp } from '../index'
 
 function testRequest(path: string) {
-  mockGlobal()
+  mockRequestScope()
   let url = new URL('https://example.com')
   url.pathname = path
   let request = new Request(url.toString())

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,10 +3,13 @@ export type CacheControl = {
   edgeTTL: number
   bypassCache: boolean
 }
+
+export type AssetManifestType = Record<string, string>
+
 export type Options = {
   cacheControl: ((req: Request) => Partial<CacheControl>) | Partial<CacheControl>
   ASSET_NAMESPACE: any
-  ASSET_MANIFEST: Object | string
+  ASSET_MANIFEST: AssetManifestType | string
   mapRequestToAsset?: (req: Request, options?: Partial<Options>) => Request
   defaultMimeType: string
   defaultDocument: string


### PR DESCRIPTION
This re-implements the work from @groenlid in #143 (thanks @groenlid!), but fixes up the issues it caused with tests. 

To solve the tests, I've split the `mocks.ts` into 2 separate mocks, one for the global scope, and one for the request scope. This way, we can mock the globals like `__STATIC_CONTENT` on the global scope as needed for tests to once again pass as expected.

Further info can be found in #143 as well as some brief benchmarks:

> Before change:
> 100 iterations: Done. Mean kv response time is 16.61
> 1000 iterations: Done. Mean kv response time is 17.798

> After change
> 100 iterations: Done. Mean kv response time is 6.62
> 1000 iterations: Done. Mean kv response time is 7.296

Closes #139 