### PR TITLE
ESM compatibility: Fix crash on missing global env vars

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ const defaultCacheControl: CacheControl = {
   bypassCache: false, // do not bypass Cloudflare's cache
 }
 
+var __STATIC_CONTENT;
+
 function assignOptions(options?: Partial<Options>): Options {
   // Assign any missing options passed in to the default
   // options.mapRequestToAsset is handled manually later

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,16 +11,14 @@ const defaultCacheControl: CacheControl = {
   bypassCache: false, // do not bypass Cloudflare's cache
 }
 
-var __STATIC_CONTENT: any;
-var __STATIC_CONTENT_MANIFEST: any;
-
 function assignOptions(options?: Partial<Options>): Options {
   // Assign any missing options passed in to the default
   // options.mapRequestToAsset is handled manually later
   return Object.assign(
     {
-      ASSET_NAMESPACE: __STATIC_CONTENT,
-      ASSET_MANIFEST: __STATIC_CONTENT_MANIFEST,
+      ASSET_NAMESPACE: typeof __STATIC_CONTENT !== 'undefined' ? __STATIC_CONTENT : undefined,
+      ASSET_MANIFEST:
+        typeof __STATIC_CONTENT_MANIFEST !== 'undefined' ? __STATIC_CONTENT_MANIFEST : undefined,
       cacheControl: defaultCacheControl,
       defaultMimeType: 'text/plain',
       defaultDocument: 'index.html',

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@ const defaultCacheControl: CacheControl = {
   bypassCache: false, // do not bypass Cloudflare's cache
 }
 
-var __STATIC_CONTENT;
-var __STATIC_CONTENT_MANIFEST;
+var __STATIC_CONTENT: any;
+var __STATIC_CONTENT_MANIFEST: any;
 
 function assignOptions(options?: Partial<Options>): Options {
   // Assign any missing options passed in to the default

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const defaultCacheControl: CacheControl = {
 }
 
 var __STATIC_CONTENT;
+var __STATIC_CONTENT_MANIFEST;
 
 function assignOptions(options?: Partial<Options>): Options {
   // Assign any missing options passed in to the default


### PR DESCRIPTION
Fixes kv-asset-handler crashing when env vars are missing as is always the case with the new ESM module syntax which wraps those in an env object that is passed explicitly.

```
ReferenceError: __STATIC_CONTENT is not defined
ReferenceError: __STATIC_CONTENT_MANIFEST is not defined
```

This partially fixes the problems reported in #174, for the other half of the solution just wrap `{ request }` and ts-ignore the typescript error to pass in the event object to `getAssetFromKV`. I did not do this change to stay backwards compatible until this is addressed properly by the Cloudflare team.