### PR TITLE
Allow changing pathIsEncoded through options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ const getAssetFromKVDefaultOptions: Partial<Options> = {
   cacheControl: defaultCacheControl,
   defaultMimeType: 'text/plain',
   defaultDocument: 'index.html',
+  pathIsEncoded: false,
 }
 
 function assignOptions(options?: Partial<Options>): Options {
@@ -114,7 +115,7 @@ const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Pr
   }
 
   const rawPathKey = new URL(request.url).pathname.replace(/^\/+/, '') // strip any preceding /'s
-  let pathIsEncoded = false
+  let pathIsEncoded = options.pathIsEncoded
   let requestKey
   // if options.mapRequestToAsset is explicitly passed in, always use it and assume user has own intentions
   // otherwise handle request as normal, with default mapRequestToAsset below

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type Options = {
   mapRequestToAsset?: (req: Request, options?: Partial<Options>) => Request
   defaultMimeType: string
   defaultDocument: string
+  pathIsEncoded: boolean
 }
 
 export class KVError extends Error {


### PR DESCRIPTION
When using `mapRequestToAsset`, it encodes the URL / key and will never check the KV store for the decoded key.

This adds the ability to set `pathIsEncoded` to true, which will decode the URL before getting it from the KV.
