### PR TITLE
Support ES Modules.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,13 @@ function serveSinglePageApp(request: Request, options?: Partial<Options>): Reque
  * @param {Object | string} [options.ASSET_NAMESPACE] the binding to the namespace that script references
  * @param {any} [options.ASSET_MANIFEST] the map of the key to cache and store in KV
  * */
-const getAssetFromKV = async (event: FetchEvent, options?: Partial<Options>): Promise<Response> => {
+
+type Evt = {
+  request: Request
+  waitUntil: (promise: Promise<any>) => void
+}
+
+const getAssetFromKV = async (event: Evt, options?: Partial<Options>): Promise<Response> => {
   options = assignOptions(options)
 
   const request = event.request


### PR DESCRIPTION
This PR provides a possible solution for getting Workers Sites working with ES Module workers. This approach is not as invasive as other approaches, so isn't as risky either.

Usage:

```jsx
import manifestJSON from "__STATIC_CONTENT_MANIFEST";
const manifest = JSON.parse(manifestJSON);

export default {
  fetch(request, env, ctx) {
    return await getAssetFromKV(
      {
        request,
        waitUntil(promise) {
          return ctx.waitUntil(promise);
        },
      },
      {
        ASSET_NAMESPACE: env.ASSET_NAMESPACE,
        ASSET_MANIFEST: manifest,
      }
    );
    // ...
  },
};
```

I'll also send a PR to wrangler that adds the manifest as a text module `__STATIC_CONTENT_MANIFEST` to the worker.

cc @xortive Is this approach right? It's following your comment here https://github.com/cloudflare/wrangler/issues/1938#issuecomment-867200289
