### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 ## 0.2.0
 
 - ### Features
@@ -48,7 +49,7 @@
 
   - **fix: default ASSET_MANIFEST to empty object - [Cherry], [pull/254]**
 
-    As per [discussion in Discord](https://canary.discord.com/channels/595317990191398933/831143699999752262/898392183999197184) and the repo at https://github.com/Erisa-bits/getassetfromkv-undefined-error, allowing `ASSET_MANIFEST` to be optional got lost somewhere along the years and errors when attempted to be used without it. This PR restores this functionality by setting it to an empty object (instead of `undefined`), which allows fall-through to the standard `mapRequestToAsset` function.
+    As per [discussion in Discord](https://canary.discord.com/channels/595317990191398933/831143699999752262/898392183999197184) and the repo at [https://github.com/Erisa-bits/getassetfromkv-undefined-error], allowing `ASSET_MANIFEST` to be optional got lost somewhere along the years and errors when attempted to be used without it. This PR restores this functionality by setting it to an empty object (instead of `undefined`), which allows fall-through to the standard `mapRequestToAsset` function.
 
     chore: bump dependencies - This updates a few dependencies and also pins `@types/node` to `15.x` since `16.x` has some incompatible types.
     feat: generate more modern code - This removes the unnecessary async/await polyfill added by TypeScript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,70 @@
 # Changelog
+## 0.2.0
+
+- ### Features
+
+  - **Allow changing pathIsEncoded through options - [JackPriceBurns], [pull/243]**
+
+    When using `mapRequestToAsset`, it encodes the URL / key and will never check the KV store for the decoded key.
+
+    This adds the ability to set `pathIsEncoded` to true, which will decode the URL before getting it from the KV.
+
+    [jackpriceburns]: https://github.com/JackPriceBurns
+    [pull/243]: https://github.com/cloudflare/kv-asset-handler/pull/243
+
+  - **Support ES Modules. - [threepointone], [pull/261]**
+
+    This PR provides a possible solution for getting Workers Sites working with ES Module workers. This approach is not as invasive as other approaches, so isn't as risky either.
+
+    Usage:
+
+    ```jsx
+    import manifestJSON from "__STATIC_CONTENT_MANIFEST";
+    const manifest = JSON.parse(manifestJSON);
+
+    export default {
+      fetch(request, env, ctx) {
+        return await getAssetFromKV(
+          {
+            request,
+            waitUntil(promise) {
+              return ctx.waitUntil(promise);
+            },
+          },
+          {
+            ASSET_NAMESPACE: env.ASSET_NAMESPACE,
+            ASSET_MANIFEST: manifest,
+          }
+        );
+        // ...
+      },
+    };
+    ```
+
+    [threepointone]: https://github.com/threepointone
+    [pull/261]: https://github.com/cloudflare/kv-asset-handler/pull/261
+
+- ### Fixes
+
+  - **fix: default ASSET_MANIFEST to empty object - [Cherry], [pull/254]**
+
+    As per [discussion in Discord](https://canary.discord.com/channels/595317990191398933/831143699999752262/898392183999197184) and the repo at https://github.com/Erisa-bits/getassetfromkv-undefined-error, allowing `ASSET_MANIFEST` to be optional got lost somewhere along the years and errors when attempted to be used without it. This PR restores this functionality by setting it to an empty object (instead of `undefined`), which allows fall-through to the standard `mapRequestToAsset` function.
+
+    chore: bump dependencies - This updates a few dependencies and also pins `@types/node` to `15.x` since `16.x` has some incompatible types.
+    feat: generate more modern code - This removes the unnecessary async/await polyfill added by TypeScript
+
+    [cherry]: https://github.com/Cherry
+    [pull/254]: https://github.com/cloudflare/kv-asset-handler/pull/254
+
+- ### Maintenance
+
+  - **chore: remove debug logs around `response.body.cancel` support - [Cherry], [pull/249]**
+
+    Fixes [issues/248]
+
+    [cherry]: https://github.com/Cherry
+    [pull/249]: https://github.com/cloudflare/kv-asset-handler/pull/249
+    [issues/248]: https://github.com/cloudflare/kv-asset-handler/issue/248
 
 ## 0.1.3
 


### PR DESCRIPTION
## 0.2.0

- ### Features

  - **Allow changing pathIsEncoded through options - [JackPriceBurns], [pull/243]**

    When using `mapRequestToAsset`, it encodes the URL / key and will never check the KV store for the decoded key.

    This adds the ability to set `pathIsEncoded` to true, which will decode the URL before getting it from the KV.

    [jackpriceburns]: https://github.com/JackPriceBurns
    [pull/243]: https://github.com/cloudflare/kv-asset-handler/pull/243

  - **Support ES Modules. - [threepointone], [pull/261]**

    This PR provides a possible solution for getting Workers Sites working with ES Module workers. This approach is not as invasive as other approaches, so isn't as risky either.

    Usage:

    ```jsx
    import manifestJSON from "__STATIC_CONTENT_MANIFEST";
    const manifest = JSON.parse(manifestJSON);

    export default {
      fetch(request, env, ctx) {
        return await getAssetFromKV(
          {
            request,
            waitUntil(promise) {
              return ctx.waitUntil(promise);
            },
          },
          {
            ASSET_NAMESPACE: env.ASSET_NAMESPACE,
            ASSET_MANIFEST: manifest,
          }
        );
        // ...
      },
    };
    ```

    [threepointone]: https://github.com/threepointone
    [pull/261]: https://github.com/cloudflare/kv-asset-handler/pull/261

- ### Fixes

  - **fix: default ASSET_MANIFEST to empty object - [Cherry], [pull/254]**

    As per [discussion in Discord](https://canary.discord.com/channels/595317990191398933/831143699999752262/898392183999197184) and the repo at https://github.com/Erisa-bits/getassetfromkv-undefined-error, allowing `ASSET_MANIFEST` to be optional got lost somewhere along the years and errors when attempted to be used without it. This PR restores this functionality by setting it to an empty object (instead of `undefined`), which allows fall-through to the standard `mapRequestToAsset` function.

    chore: bump dependencies - This updates a few dependencies and also pins `@types/node` to `15.x` since `16.x` has some incompatible types.
    feat: generate more modern code - This removes the unnecessary async/await polyfill added by TypeScript

    [cherry]: https://github.com/Cherry
    [pull/254]: https://github.com/cloudflare/kv-asset-handler/pull/254

- ### Maintenance

  - **chore: remove debug logs around `response.body.cancel` support - [Cherry], [pull/249]**

    Fixes [issues/248]

    [cherry]: https://github.com/Cherry
    [pull/249]: https://github.com/cloudflare/kv-asset-handler/pull/249
    [issues/248]: https://github.com/cloudflare/kv-asset-handler/issue/248