### PR TITLE
s/`env.ASSET_NAMESPACE`/`env.__STATIC_CONTENT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export default {
             },
           },
           {
-            ASSET_NAMESPACE: env.ASSET_NAMESPACE,
+            ASSET_NAMESPACE: env.__STATIC_CONTENT,
             ASSET_MANIFEST: assetManifest,
           },
         )
@@ -219,7 +219,7 @@ return getAssetFromKV(
     },
   },
   {
-    ASSET_NAMESPACE: env.ASSET_NAMESPACE,
+    ASSET_NAMESPACE: env.__STATIC_CONTENT,
   },
 )
 ```


### PR DESCRIPTION
The KV namespace on `env` is called `__STATIC_CONTENT`. This PR fixes the example snippets with the same.