### PR TITLE
Allow configurable downgrade of ETag validator strength

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The Cloudflare Workers Discord server is an active place where Workers users get
       - [`bypassCache`](#bypasscache)
     - [`ASSET_NAMESPACE` (required for ES Modules)](#asset_namespace-required-for-es-modules)
     - [`ASSET_MANIFEST` (required for ES Modules)](#asset_manifest-required-for-es-modules)
+    - [`defaultETag`](#defaultetag-optional)
 
 * [Helper functions](#helper-functions)
   - [`mapRequestToAsset`](#maprequesttoasset-1)
@@ -281,6 +282,13 @@ If you are serving a static site and would like to use extensionless HTML files 
 type: string
 
 This is the default document that will be concatenated for requests ends in `'/'` or without a valid mime type like `'/about'` or `'/about.me'`. The default value is `'index.html'`.
+
+#### `defaultETag` (optional)
+
+type: `'strong' | 'weak'`
+
+This determines the format of the response [ETag header](https://developer.mozilla.org/docs/Web/HTTP/Headers/ETag). If the resource is in the cache, the ETag will always be weakened before being returned.
+The default value is `'strong'`.
 
 # Helper functions
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type Options = {
   defaultMimeType: string
   defaultDocument: string
   pathIsEncoded: boolean
+  defaultETag: 'strong' | 'weak'
 }
 
 export class KVError extends Error {


### PR DESCRIPTION
This PR allows users to override the default strong ETag validator behaviour to use weak ETag validators. 

I was encountering issues where my worker's returned strong ETags were automatically converted to weak ETags by Cloudflare. This change allows the developer to use weak ETags and preserve 304 responses (e.g. on `*.workers.dev` domains).

The alternative to this is specifying page rules to preserve strong ETags (possibly enterprise only)

- [x] Change has unit tests
- [x] Readme has been updated with documentation and usage
- [x] This is a backwards compatible change
- [x] I have tested this on my own Cloudflare workers