### PR TITLE
Remove tests from npm package to reduce npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
 	"files": [
 		"src",
 		"dist",
+		"!src/test",
+		"!dist/test",
 		"LICENSE_APACHE",
 		"LICENSE_MIT"
 	],


### PR DESCRIPTION
Excluding the tests from the package reduces its install size by about half (tested with `npm` 9.8.0).
Before:
```
❯ npm pack
...
npm notice === Tarball Details ===
npm notice name:          @cloudflare/kv-asset-handler
npm notice version:       0.3.0
npm notice filename:      cloudflare-kv-asset-handler-0.3.0.tgz
npm notice package size:  25.3 kB
npm notice unpacked size: 112.1 kB
npm notice shasum:        11f0af0749a400ddadcca16dcd6f4696d7036991
npm notice integrity:     sha512-9CB/MKf/wdvbf[...]DlNrDcDhdWHSQ==
npm notice total files:   25
```
After:
```
❯ npm pack
...
npm notice === Tarball Details ===
npm notice name:          @cloudflare/kv-asset-handler
npm notice version:       0.3.0
npm notice filename:      cloudflare-kv-asset-handler-0.3.0.tgz
npm notice package size:  19.8 kB
npm notice unpacked size: 66.0 kB
npm notice shasum:        ffd10c82056c54dd2b0cd59017f16fbca88dd956
npm notice integrity:     sha512-e1CuDkBEtFcu+[...]0zISBUJOnC9TQ==
npm notice total files:   13
```